### PR TITLE
Added support for topics.regex

### DIFF
--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkConfig.java
@@ -18,15 +18,19 @@
 
 package com.mongodb.kafka.connect.sink;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.TOPIC_OVERRIDE_PREFIX;
 import static com.mongodb.kafka.connect.util.Validators.errorCheckingValueValidator;
 import static java.lang.String.format;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.unmodifiableList;
 import static java.util.Collections.unmodifiableMap;
-import static org.apache.kafka.common.config.ConfigDef.NO_DEFAULT_VALUE;
 import static org.apache.kafka.common.config.ConfigDef.Width;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.AbstractConfig;
@@ -44,8 +48,17 @@ import com.mongodb.kafka.connect.util.Validators;
 public class MongoSinkConfig extends AbstractConfig {
 
     public static final String TOPICS_CONFIG = MongoSinkConnector.TOPICS_CONFIG;
+    private static final String TOPICS_DOC = "A list of kafka topics for the sink connector, separated by commas";
+    public static final String TOPICS_DEFAULT = "";
     private static final String TOPICS_DISPLAY = "The Kafka topics";
-    private static final String TOPICS_DOC = "A list of kafka topics for the sink connector.";
+
+    public static final String TOPICS_REGEX_CONFIG = "topics.regex";
+    private static final String TOPICS_REGEX_DOC = "Regular expression giving topics to consume. "
+            + "Under the hood, the regex is compiled to a <code>java.util.regex.Pattern</code>. "
+            + "Only one of " + TOPICS_CONFIG + " or " + TOPICS_REGEX_CONFIG + " should be specified.";
+    public static final String TOPICS_REGEX_DEFAULT = "";
+    private static final String TOPICS_REGEX_DISPLAY = "Topics regex";
+
 
     public static final String CONNECTION_URI_CONFIG = "connection.uri";
     private static final String CONNECTION_URI_DEFAULT = "mongodb://localhost:27017";
@@ -62,17 +75,39 @@ public class MongoSinkConfig extends AbstractConfig {
             + "Note: All configuration options apart from '" + CONNECTION_URI_CONFIG + "' and '" + TOPICS_CONFIG + "' are overridable.";
 
     private Map<String, String> originals;
-    private final List<String> topics;
+    private final Optional<List<String>> topics;
+    private final Optional<Pattern> topicsRegex;
     private Map<String, MongoSinkTopicConfig> topicSinkConnectorConfigMap;
     private ConnectionString connectionString;
 
     MongoSinkConfig(final Map<String, String> originals) {
         super(CONFIG, originals, false);
         this.originals = unmodifiableMap(originals);
-        topics = unmodifiableList(getList(TOPICS_CONFIG));
-        connectionString = new ConnectionString(getString(CONNECTION_URI_CONFIG));
 
-        topics.forEach(this::getMongoSinkTopicConfig);
+        topics = getList(TOPICS_CONFIG).isEmpty() ? Optional.empty() : Optional.of(unmodifiableList(getList(TOPICS_CONFIG)));
+        topicsRegex = getString(TOPICS_REGEX_CONFIG).isEmpty() ? Optional.empty()
+                : Optional.of(Pattern.compile(getString(TOPICS_REGEX_CONFIG)));
+
+        if (topics.isPresent() && topicsRegex.isPresent()) {
+            throw new ConfigException(format("%s and %s are mutually exclusive options, but both are set.", TOPICS_CONFIG,
+                    TOPICS_REGEX_CONFIG));
+        } else if (!topics.isPresent() && !topicsRegex.isPresent()) {
+            throw new ConfigException(format("Must configure one of %s or %s", TOPICS_CONFIG, TOPICS_REGEX_CONFIG));
+        }
+
+        connectionString = new ConnectionString(getString(CONNECTION_URI_CONFIG));
+        topicSinkConnectorConfigMap = new ConcurrentHashMap<>(topics.orElse(emptyList()).stream()
+                .collect(Collectors.toMap((t) -> t, (t) -> new MongoSinkTopicConfig(t, originals))));
+
+        // Process and validate overrides of regex values.
+        if (topicsRegex.isPresent()) {
+            originals.keySet().stream().filter(k -> k.startsWith(TOPIC_OVERRIDE_PREFIX)).forEach(k -> {
+                String topic = k.substring(TOPIC_OVERRIDE_PREFIX.length()).split("\\.")[0];
+                if (!topicSinkConnectorConfigMap.containsKey(topic)) {
+                    topicSinkConnectorConfigMap.put(topic, new MongoSinkTopicConfig(topic, originals));
+                }
+            });
+        }
     }
 
     public static final ConfigDef CONFIG = createConfigDef();
@@ -88,23 +123,30 @@ public class MongoSinkConfig extends AbstractConfig {
         return connectionString;
     }
 
-    List<String> getTopics() {
+    Optional<List<String>> getTopics() {
         return topics;
     }
 
-    MongoSinkTopicConfig getMongoSinkTopicConfig(final String topic) {
-        if (!topics.contains(topic)) {
-            throw new IllegalArgumentException(format("Unknown topic: %s, must be one of: %s", topic, topics));
-        }
-        if (topicSinkConnectorConfigMap == null) {
-            createMongoSinkTopicConfig();
-        }
-        return topicSinkConnectorConfigMap.get(topic);
+    Optional<Pattern> getTopicRegex() {
+        return topicsRegex;
     }
 
-    private void createMongoSinkTopicConfig() {
-        topicSinkConnectorConfigMap = topics.stream()
-                .collect(Collectors.toMap((t) -> t, (t) -> new MongoSinkTopicConfig(t, originals)));
+    MongoSinkTopicConfig getMongoSinkTopicConfig(final String topic) {
+        topics.ifPresent(topicsList -> {
+            if (!topicsList.contains(topic)) {
+                throw new ConfigException(format("Unknown topic: %s, must be one of: %s", topic, topicsList));
+            }
+        });
+        topicsRegex.ifPresent(topicRegex -> {
+            if (!topicRegex.matcher(topic).matches()) {
+                throw new ConfigException(format("Unknown topic: %s, does not match: %s", topic, topicRegex));
+            }
+            if (!topicSinkConnectorConfigMap.containsKey(topic)) {
+                topicSinkConnectorConfigMap.put(topic, new MongoSinkTopicConfig(topic, originals));
+            }
+        });
+
+        return topicSinkConnectorConfigMap.get(topic);
     }
 
     private static ConfigDef createConfigDef() {
@@ -119,9 +161,23 @@ public class MongoSinkConfig extends AbstractConfig {
                     return results;
                 }
 
-                // Validate any topic based configs
-                List<String> topics = (List<String>) results.get(TOPICS_CONFIG).value();
-                topics.forEach(topic -> results.putAll(MongoSinkTopicConfig.validateAll(topic, props)));
+                boolean hasTopicsConfig = !props.getOrDefault(TOPICS_CONFIG, "").trim().isEmpty();
+                boolean hasTopicsRegexConfig = !props.getOrDefault(TOPICS_REGEX_CONFIG, "").trim().isEmpty();
+
+                if (hasTopicsConfig && hasTopicsRegexConfig) {
+                    results.get(TOPICS_CONFIG).addErrorMessage(
+                            format("%s and %s are mutually exclusive options, but both are set.", TOPICS_CONFIG, TOPICS_REGEX_CONFIG));
+                } else if (!hasTopicsConfig && !hasTopicsRegexConfig) {
+                    results.get(TOPICS_CONFIG).addErrorMessage(
+                            format("Must configure one of %s or %s", TOPICS_CONFIG, TOPICS_REGEX_CONFIG));
+                }
+
+                if (hasTopicsConfig) {
+                    List<String> topics = (List<String>) results.get(TOPICS_CONFIG).value();
+                    topics.forEach(topic -> results.putAll(MongoSinkTopicConfig.validateAll(topic, props)));
+                } else if (hasTopicsRegexConfig) {
+                    results.putAll(MongoSinkTopicConfig.validateRegexAll(props));
+                }
                 return results;
             }
         };
@@ -129,14 +185,25 @@ public class MongoSinkConfig extends AbstractConfig {
         int orderInGroup = 0;
         configDef.define(TOPICS_CONFIG,
                 Type.LIST,
-                NO_DEFAULT_VALUE,
-                Validators.nonEmptyList(),
+                TOPICS_DEFAULT,
                 Importance.HIGH,
                 TOPICS_DOC,
                 group,
                 ++orderInGroup,
                 Width.MEDIUM,
                 TOPICS_DISPLAY);
+
+        configDef.define(TOPICS_REGEX_CONFIG,
+                Type.STRING,
+                TOPICS_REGEX_DEFAULT,
+                Validators.isAValidRegex(),
+                Importance.HIGH,
+                TOPICS_REGEX_DOC,
+                group,
+                ++orderInGroup,
+                Width.MEDIUM,
+                TOPICS_REGEX_DISPLAY);
+
         configDef.define(CONNECTION_URI_CONFIG,
                 Type.STRING,
                 CONNECTION_URI_DEFAULT,

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTask.java
@@ -22,6 +22,7 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.MAX_BATCH_SIZE
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.MAX_NUM_RETRIES_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.RETRIES_DEFER_TIMEOUT_CONFIG;
 import static com.mongodb.kafka.connect.util.ConfigHelper.getMongoDriverInformation;
+import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -85,7 +86,8 @@ public class MongoSinkTask extends SinkTask {
         LOGGER.info("Starting MongoDB sink task");
         try {
             sinkConfig = new MongoSinkConfig(props);
-            remainingRetriesTopicMap = new ConcurrentHashMap<>(sinkConfig.getTopics().stream().collect(Collectors.toMap((t) -> t,
+            remainingRetriesTopicMap = new ConcurrentHashMap<>(sinkConfig.getTopics().orElse(emptyList()).stream()
+                    .collect(Collectors.toMap((t) -> t,
                             (t) -> new AtomicInteger(sinkConfig.getMongoSinkTopicConfig(t).getInt(MAX_NUM_RETRIES_CONFIG)))));
         } catch (Exception e) {
             throw new ConnectException("Failed to start new task", e);
@@ -186,13 +188,21 @@ public class MongoSinkTask extends SinkTask {
         } catch (MongoException e) {
             LOGGER.error("Error on mongodb operation", e);
             LOGGER.error("Writing {} document(s) into collection [{}] failed -> remaining retries ({})",
-                    writeModels.size(), config.getNamespace().getFullName(), remainingRetriesTopicMap.get(config.getTopic()).get());
+                    writeModels.size(), config.getNamespace().getFullName(), getRemainingRetriesForTopic(config.getTopic()).get());
             checkRetriableException(config, e);
         }
     }
 
+    private AtomicInteger getRemainingRetriesForTopic(final String topic) {
+        if (!remainingRetriesTopicMap.containsKey(topic)) {
+            remainingRetriesTopicMap.put(topic, new AtomicInteger(sinkConfig.getMongoSinkTopicConfig(topic)
+                    .getInt(MAX_NUM_RETRIES_CONFIG)));
+        }
+        return remainingRetriesTopicMap.get(topic);
+    }
+
     private void checkRetriableException(final MongoSinkTopicConfig config, final MongoException e) {
-        if (remainingRetriesTopicMap.get(config.getTopic()).decrementAndGet() <= 0) {
+        if (getRemainingRetriesForTopic(config.getTopic()).decrementAndGet() <= 0) {
             throw new DataException("Failed to write mongodb documents despite retrying", e);
         }
         Integer deferRetryMs = config.getInt(RETRIES_DEFER_TIMEOUT_CONFIG);

--- a/src/main/java/com/mongodb/kafka/connect/util/Validators.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/Validators.java
@@ -73,10 +73,12 @@ public final class Validators {
         }));
     }
 
-    public static ValidatorWithOperators nonEmptyList() {
-        return withStringDef("A non-empty list", ((name, value) -> {
-            if (value != null && ((List) value).isEmpty()) {
-                throw new ConfigException(name, value, "Empty list");
+    public static ValidatorWithOperators isAValidRegex() {
+        return withStringDef("A valid regex", ((name, value) -> {
+            try {
+                Pattern.compile((String) value);
+            } catch (Exception e) {
+                throw new ConfigException(name, value, "Invalid regex: " + e.getMessage());
             }
         }));
     }

--- a/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/MongoSinkConfigTest.java
@@ -19,6 +19,7 @@
 package com.mongodb.kafka.connect.sink;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.CONNECTION_URI_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_REGEX_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPIC_OVERRIDE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.createOverrideKey;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.CHANGE_DATA_CAPTURE_HANDLER_CONFIG;
@@ -40,11 +41,13 @@ import static com.mongodb.kafka.connect.sink.SinkTestHelper.createConfigMap;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createSinkConfig;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
+import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertIterableEquals;
@@ -60,6 +63,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.apache.kafka.common.config.ConfigException;
@@ -99,6 +103,7 @@ import com.github.jcustenborder.kafka.connect.utils.config.MarkdownFormatter;
 
 @RunWith(JUnitPlatform.class)
 class MongoSinkConfigTest {
+    private static final Pattern EMPTY_PATTERN = Pattern.compile("");
 
     @Test
     @DisplayName("build config doc (no test)")
@@ -125,10 +130,30 @@ class MongoSinkConfigTest {
     @DisplayName("test topics")
     void testTopics() {
         assertAll("topics",
-                () -> assertEquals(singletonList("a"), createSinkConfig(TOPICS_CONFIG, "a").getTopics()),
-                () -> assertEquals(asList("a", "b", "c"), createSinkConfig(TOPICS_CONFIG, "a,b,c").getTopics()),
+                () -> assertEquals(singletonList("a"), createSinkConfig(TOPICS_CONFIG, "a").getTopics().orElse(emptyList())),
+                () -> assertEquals(asList("a", "b", "c"), createSinkConfig(TOPICS_CONFIG, "a,b,c").getTopics().orElse(emptyList())),
                 () -> assertInvalid(TOPICS_CONFIG, "")
         );
+    }
+
+    @Test
+    @DisplayName("test topic regex")
+    void testTopicRegex() {
+        assertAll("topics",
+                () -> assertPattern(".*", createSinkConfig(TOPICS_REGEX_CONFIG, ".*").getTopicRegex().orElse(EMPTY_PATTERN)),
+                () -> assertInvalid(TOPICS_REGEX_CONFIG, "["),
+                () -> assertDoesNotThrow(() -> createSinkConfig(TOPICS_REGEX_CONFIG, "topic-(.*)").getMongoSinkTopicConfig("topic-1")),
+                () -> assertThrows(ConfigException.class,
+                        () -> createSinkConfig(TOPICS_REGEX_CONFIG, "topic-(.*)").getMongoSinkTopicConfig("alpha"))
+        );
+    }
+
+    @Test
+    @DisplayName("test topics and topic regex")
+    void testTopicsAndTopicRegex() {
+        Map<String, String> configMap = createConfigMap();
+        configMap.put(TOPICS_REGEX_CONFIG, ".*");
+        assertInvalid(TOPICS_CONFIG, configMap);
     }
 
     @Test
@@ -140,12 +165,26 @@ class MongoSinkConfigTest {
     @Test
     @DisplayName("test topic overrides")
     void testTopicOverrides() {
-        MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format("{'topics': 'topic,t2', '%s': 'otherDB', '%s': 'coll2'}",
-                createOverrideKey("t2", DATABASE_CONFIG), createOverrideKey("t2", COLLECTION_CONFIG)));
-        assertThat(cfg.getTopics(), containsInAnyOrder("topic", "t2"));
+        MongoSinkConfig cfg = createSinkConfig(format("{'%s': 'topic,t2', '%s': 'otherDB', '%s': 'coll2'}",
+                TOPICS_CONFIG, createOverrideKey("t2", DATABASE_CONFIG), createOverrideKey("t2", COLLECTION_CONFIG)));
+        assertThat(cfg.getTopics().orElse(emptyList()), containsInAnyOrder("topic", "t2"));
 
         assertEquals("myDB.topic", cfg.getMongoSinkTopicConfig("topic").getNamespace().toString());
         assertEquals("otherDB.coll2", cfg.getMongoSinkTopicConfig("t2").getNamespace().toString());
+    }
+
+    @Test
+    @DisplayName("test topic regex with overrides")
+    void testTopicRegexWithOverrides() {
+        MongoSinkConfig cfg = createSinkConfig(format("{'%s': 't(.*)', '%s': 'otherDB', '%s': 'coll2', '%s': 'coll3'}",
+                TOPICS_REGEX_CONFIG, createOverrideKey("t2", DATABASE_CONFIG), createOverrideKey("t2", COLLECTION_CONFIG),
+                createOverrideKey("noMatch", COLLECTION_CONFIG)));
+        assertPattern("t(.*)", cfg.getTopicRegex().orElse(EMPTY_PATTERN));
+        assertEquals("myDB.topic", cfg.getMongoSinkTopicConfig("topic").getNamespace().toString());
+        assertEquals("otherDB.coll2", cfg.getMongoSinkTopicConfig("t2").getNamespace().toString());
+        assertThrows(ConfigException.class, () -> cfg.getMongoSinkTopicConfig("noMatch"));
+        assertThrows(ConfigException.class, () -> createSinkConfig(format("{'%s': 't(.*)', '%s': 'made up'}",
+                TOPICS_REGEX_CONFIG, createOverrideKey("t2", KEY_PROJECTION_TYPE_CONFIG))));
     }
 
     @Test
@@ -162,7 +201,7 @@ class MongoSinkConfigTest {
     void testCorrectFieldSetForKeyAndValueBlacklistProjectionList() {
         String fieldList = " ,field1, field2.subA ,  field2.subB,  field3.** , ,,  ";
         Set<String> blacklisted = new HashSet<>(asList("field1", "field2.subA", "field2.subB", "field3.**"));
-        MongoSinkConfig keyConfig = SinkTestHelper.createSinkConfig(format("{'%s': '%s', '%s': 'blacklist', '%s': '%s'}",
+        MongoSinkConfig keyConfig = createSinkConfig(format("{'%s': '%s', '%s': 'blacklist', '%s': '%s'}",
                 DOCUMENT_ID_STRATEGY_CONFIG, PartialKeyStrategy.class.getName(),
                 KEY_PROJECTION_TYPE_CONFIG, KEY_PROJECTION_LIST_CONFIG, fieldList));
 
@@ -170,7 +209,7 @@ class MongoSinkConfigTest {
         assertTrue(idStrategy instanceof PartialKeyStrategy);
         assertIterableEquals(((PartialKeyStrategy) idStrategy).getFieldProjector().getFields(), blacklisted);
 
-        MongoSinkConfig valueConfig = SinkTestHelper.createSinkConfig(format("{'%s': '%s', '%s': 'blacklist', '%s': '%s'}",
+        MongoSinkConfig valueConfig = createSinkConfig(format("{'%s': '%s', '%s': 'blacklist', '%s': '%s'}",
                 DOCUMENT_ID_STRATEGY_CONFIG, PartialValueStrategy.class.getName(),
                 VALUE_PROJECTION_TYPE_CONFIG, VALUE_PROJECTION_LIST_CONFIG, fieldList));
 
@@ -187,7 +226,7 @@ class MongoSinkConfigTest {
         Set<String> whitelisted = new HashSet<>(asList("field1", "field1.**", "field2", "field2.*", "field2.*.subSubA",
                 "field2.subB", "field2.subB.*", "field3", "field3.subC", "field3.subC.subSubD"));
 
-        MongoSinkConfig keyConfig = SinkTestHelper.createSinkConfig(format("{'%s': '%s', '%s': 'whitelist', '%s': '%s'}",
+        MongoSinkConfig keyConfig = createSinkConfig(format("{'%s': '%s', '%s': 'whitelist', '%s': '%s'}",
                 DOCUMENT_ID_STRATEGY_CONFIG, PartialKeyStrategy.class.getName(),
                 KEY_PROJECTION_TYPE_CONFIG, KEY_PROJECTION_LIST_CONFIG, fieldList));
 
@@ -195,7 +234,7 @@ class MongoSinkConfigTest {
         assertTrue(idStrategy instanceof PartialKeyStrategy);
         assertIterableEquals(((PartialKeyStrategy) idStrategy).getFieldProjector().getFields(), whitelisted);
 
-        MongoSinkConfig valueConfig = SinkTestHelper.createSinkConfig(format("{'%s': '%s', '%s': 'whitelist', '%s': '%s'}",
+        MongoSinkConfig valueConfig = createSinkConfig(format("{'%s': '%s', '%s': 'whitelist', '%s': '%s'}",
                 DOCUMENT_ID_STRATEGY_CONFIG, PartialValueStrategy.class.getName(),
                 VALUE_PROJECTION_TYPE_CONFIG, VALUE_PROJECTION_LIST_CONFIG, fieldList));
 
@@ -218,14 +257,14 @@ class MongoSinkConfigTest {
             String projectionType = s.contains("Value") ? VALUE_PROJECTION_TYPE_CONFIG : KEY_PROJECTION_TYPE_CONFIG;
             idStrategyTests.add(
                     dynamicTest("blacklist: test id strategy for " + s, () -> {
-                        MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format(json, projectionType, "blacklist",
+                        MongoSinkConfig cfg = createSinkConfig(format(json, projectionType, "blacklist",
                                 DOCUMENT_ID_STRATEGY_CONFIG, s));
                         assertEquals(cfg.getMongoSinkTopicConfig(TEST_TOPIC).getIdStrategy().getClass().getName(), s);
                     }));
 
             idStrategyTests.add(
                     dynamicTest("whiltelist: test id strategy for " + s, () -> {
-                        MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format(json, projectionType, "whitelist",
+                        MongoSinkConfig cfg = createSinkConfig(format(json, projectionType, "whitelist",
                                 DOCUMENT_ID_STRATEGY_CONFIG, s));
                         assertEquals(cfg.getMongoSinkTopicConfig(TEST_TOPIC).getIdStrategy().getClass().getName(), s);
                     }));
@@ -262,7 +301,7 @@ class MongoSinkConfigTest {
                 PostgresHandler.class.getName());
         cdcHandlers.forEach(s -> tests.add(
                 dynamicTest("cdc Handler for " + s, () -> {
-                    MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format(json, CHANGE_DATA_CAPTURE_HANDLER_CONFIG, s));
+                    MongoSinkConfig cfg = createSinkConfig(format(json, CHANGE_DATA_CAPTURE_HANDLER_CONFIG, s));
                     assertEquals(cfg.getMongoSinkTopicConfig(TEST_TOPIC).getCdcHandler().get().getClass().getName(), s);
                 })));
         return tests;
@@ -285,14 +324,14 @@ class MongoSinkConfigTest {
 
         assertAll("field name mappings",
             () -> {
-                MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format(json, FIELD_RENAMER_MAPPING_CONFIG, "[]"));
+                MongoSinkConfig cfg = createSinkConfig(format(json, FIELD_RENAMER_MAPPING_CONFIG, "[]"));
             List<PostProcessor> pp = cfg.getMongoSinkTopicConfig(TEST_TOPIC).getPostProcessors().getPostProcessorList();
 
             assertEquals(2, pp.size());
                 assertTrue(pp.get(1) instanceof RenameByMapping);
         },
         () -> {
-            MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format(json, FIELD_RENAMER_MAPPING_CONFIG,
+            MongoSinkConfig cfg = createSinkConfig(format(json, FIELD_RENAMER_MAPPING_CONFIG,
                     "[{\"oldName\":\"key.fieldA\",\"newName\":\"field1\"},{\"oldName\":\"value.xyz\",\"newName\":\"abc\"}]"));
             List<PostProcessor> pp = cfg.getMongoSinkTopicConfig(TEST_TOPIC).getPostProcessors().getPostProcessorList();
 
@@ -309,14 +348,14 @@ class MongoSinkConfigTest {
         String json = format("{'%s': '%s', '%%s': '%%s'}", POST_PROCESSOR_CHAIN_CONFIG, postProcessors);
         assertAll("field name mappings",
                 () -> {
-                    MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format(json, FIELD_RENAMER_REGEXP_CONFIG, "[]"));
+                    MongoSinkConfig cfg = createSinkConfig(format(json, FIELD_RENAMER_REGEXP_CONFIG, "[]"));
                     List<PostProcessor> pp = cfg.getMongoSinkTopicConfig(TEST_TOPIC).getPostProcessors().getPostProcessorList();
 
                     assertEquals(2, pp.size());
                     assertTrue(pp.get(1) instanceof RenameByRegExp);
                 },
                 () -> {
-                    MongoSinkConfig cfg = SinkTestHelper.createSinkConfig(format(json, FIELD_RENAMER_REGEXP_CONFIG,
+                    MongoSinkConfig cfg = createSinkConfig(format(json, FIELD_RENAMER_REGEXP_CONFIG,
                             "[{\"regexp\":\"^key\\\\\\\\..*my.*$\",\"pattern\":\"my\",\"replace\":\"\"},"
                             + "{\"regexp\":\"^value\\\\\\\\..*$\",\"pattern\":\"\\\\\\\\.\",\"replace\":\"_\"}]"));
                     List<PostProcessor> pp = cfg.getMongoSinkTopicConfig(TEST_TOPIC).getPostProcessors().getPostProcessorList();
@@ -351,7 +390,7 @@ class MongoSinkConfigTest {
                 String.join(",", value)));
 
         MongoSinkConfig mongoSinkConfig = new MongoSinkConfig(map);
-        mongoSinkConfig.getTopics().stream().map(mongoSinkConfig::getMongoSinkTopicConfig).forEach(cfg ->
+        mongoSinkConfig.getTopics().orElse(emptyList()).stream().map(mongoSinkConfig::getMongoSinkTopicConfig).forEach(cfg ->
                 tests.add(dynamicTest("verify resulting chain - inspecting: " + cfg.getTopic(), () -> {
                     List<Class> pp = cfg.getPostProcessors().getPostProcessorList().stream().map(PostProcessor::getClass)
                             .collect(Collectors.toList());
@@ -408,7 +447,7 @@ class MongoSinkConfigTest {
         candidates.forEach((topic, clazz) -> map.put(format(TOPIC_OVERRIDE_CONFIG, topic, WRITEMODEL_STRATEGY_CONFIG), clazz.getName()));
 
         MongoSinkConfig mongoSinkConfig = new MongoSinkConfig(map);
-        mongoSinkConfig.getTopics().stream().map(mongoSinkConfig::getMongoSinkTopicConfig).forEach(cfg ->
+        mongoSinkConfig.getTopics().orElse(emptyList()).stream().map(mongoSinkConfig::getMongoSinkTopicConfig).forEach(cfg ->
                 assertEquals(candidates.get(cfg.getTopic()), cfg.getWriteModelStrategy().getClass(),
                     "write model for " + cfg.getTopic() + " strategy NOT of type " + candidates.get(cfg.getTopic())));
     }
@@ -420,5 +459,9 @@ class MongoSinkConfigTest {
     private void assertInvalid(final String invalidKey, final Map<String, String> configMap) {
         assertFalse(MongoSinkConfig.CONFIG.validateAll(configMap).get(invalidKey).errorMessages().isEmpty());
         assertThrows(ConfigException.class, () -> new MongoSinkConfig(configMap));
+    }
+
+    private void assertPattern(final String expected, final Pattern actual) {
+        assertEquals(expected, actual.pattern());
     }
 }

--- a/src/test/java/com/mongodb/kafka/connect/sink/SinkTestHelper.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/SinkTestHelper.java
@@ -17,6 +17,7 @@ package com.mongodb.kafka.connect.sink;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DATABASE_CONFIG;
 import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_CONFIG;
+import static org.apache.kafka.connect.runtime.SinkConnectorConfig.TOPICS_REGEX_CONFIG;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,12 +41,20 @@ public final class SinkTestHelper {
 
     public static  Map<String, String> createConfigMap(final String json) {
         Map<String, String> map = createConfigMap();
-        Document.parse(json).forEach((k, v) -> map.put(k, v.toString()));
+        Document.parse(json).forEach((k, v) -> {
+            if (k.equals(TOPICS_REGEX_CONFIG)) {
+                map.remove(TOPICS_CONFIG);
+            }
+            map.put(k, v.toString());
+        });
         return map;
     }
 
     public static Map<String, String> createConfigMap(final String k, final String v) {
         Map<String, String> map = createConfigMap();
+        if (k.equals(TOPICS_REGEX_CONFIG)) {
+            map.remove(TOPICS_CONFIG);
+        }
         map.put(k, v);
         return map;
     }


### PR DESCRIPTION
Users now must set either the topics list or a topics regex as per: https://docs.confluent.io/current/installation/configuration/connect/sink-connect-configs.html


https://evergreen.mongodb.com/version/5e971c963e8e86625a2a9576

KAFKA-82