### PR TITLE
Allow the Sink connector to use multiple tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Changelog
 
+## 1.2.0
+  - [KAFKA-92](https://jira.mongodb.org/browse/KAFKA-92) Allow the Sink connector to use multiple tasks.
+
 ## 1.1.0
   - [KAFKA-45](https://jira.mongodb.org/browse/KAFKA-45) Allow the Sink connector to ignore unused source record key or value fields.
   - [KAFKA-82](https://jira.mongodb.org/browse/KAFKA-82) Added support for "topics.regex" in the Sink connector.

--- a/src/integrationTest/java/com/mongodb/kafka/connect/MongoSinkConnectorTest.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/MongoSinkConnectorTest.java
@@ -15,17 +15,24 @@
  */
 package com.mongodb.kafka.connect;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPICS_REGEX_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkConfig.TOPIC_OVERRIDE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.COLLECTION_CONFIG;
 import static java.lang.String.format;
 import static java.util.Arrays.asList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
+import java.util.Random;
+import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.LongStream;
 
 import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 
@@ -34,11 +41,15 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.opentest4j.AssertionFailedError;
+
+import com.mongodb.client.model.Sorts;
 
 import com.mongodb.kafka.connect.avro.TweetMsg;
 import com.mongodb.kafka.connect.mongodb.MongoKafkaTestCase;
 
 class MongoSinkConnectorTest extends MongoKafkaTestCase {
+    private static final Random RANDOM = new Random();
 
     @Test
     @DisplayName("Ensure sink connect saves data to MongoDB")
@@ -48,6 +59,74 @@ class MongoSinkConnectorTest extends MongoKafkaTestCase {
         addSinkConnector(topicName);
 
         assertProducesMessages(topicName, getCollectionName());
+    }
+
+    @Test
+    @DisplayName("Ensure sink saves data using multiple tasks and a single partition")
+    void testSinkSavesUsingMultipleTasksWithASinglePartition() {
+        String topicName = getTopicName();
+        KAFKA.createTopic(topicName, 3, 1);
+
+        Properties sinkProperties = new Properties();
+        sinkProperties.put(TOPICS_CONFIG, topicName);
+        sinkProperties.put("tasks.max", "5");
+        addSinkConnector(sinkProperties);
+
+        assertProducesMessages(topicName, getCollectionName());
+        assertCollectionOrder(true);
+    }
+
+    @Test
+    @DisplayName("Ensure sink saves data using a single task and multiple partitions")
+    void testSinkSavesUsingASingleTasksWithMultiplePartitions() {
+        String topicName = getTopicName();
+        int partitionCount = 3;
+        KAFKA.createTopic(topicName, partitionCount, 1);
+
+        addSinkConnector(topicName);
+        assertProducesMessages(topicName, getCollectionName(), partitionCount);
+        assertCollectionOrder(false);
+    }
+
+    @Test
+    @DisplayName("Ensure sink saves data using multiple tasks and multiple partitions")
+    void testSinkSavesUsingMultipleTasksWithMultiplePartitions() {
+        String topicName = getTopicName();
+        int partitionCount = 3;
+        KAFKA.createTopic(topicName, partitionCount, 1);
+
+        Properties sinkProperties = new Properties();
+        sinkProperties.put(TOPICS_CONFIG, topicName);
+        sinkProperties.put("tasks.max", "5");
+        addSinkConnector(sinkProperties);
+
+        assertProducesMessages(topicName, getCollectionName(), partitionCount);
+        assertCollectionOrder(false);
+    }
+
+    @Test
+    @DisplayName("Ensure sink saves data to multiple collections using multiple tasks and multiple partitions")
+    void testSinkSavesToMultipleCollectionsUsingMultipleTasksWithMultiplePartitions() {
+        String topicName1 = getTopicName();
+        String topicName2 = getTopicName();
+        String collectionName1 = topicName1 + "Collection";
+        String collectionName2 = topicName2 + "Collection";
+
+        int partitionCount = 3;
+        KAFKA.createTopic(topicName1);
+        KAFKA.createTopic(topicName2, partitionCount, 1);
+
+        Properties sinkProperties = new Properties();
+        sinkProperties.put(TOPICS_CONFIG, format("%s,%s", topicName1, topicName2));
+        sinkProperties.put(format(TOPIC_OVERRIDE_CONFIG, topicName1, COLLECTION_CONFIG), collectionName1);
+        sinkProperties.put(format(TOPIC_OVERRIDE_CONFIG, topicName2, COLLECTION_CONFIG), collectionName2);
+        sinkProperties.put("tasks.max", "5");
+        addSinkConnector(sinkProperties);
+
+        assertProducesMessages(topicName1, collectionName1);
+        assertProducesMessages(topicName2, collectionName2, partitionCount);
+        assertCollectionOrder(collectionName1, true);
+        assertCollectionOrder(collectionName2, false);
     }
 
     @Test
@@ -86,6 +165,15 @@ class MongoSinkConnectorTest extends MongoKafkaTestCase {
     }
 
     private void assertProducesMessages(final String topicName, final String collectionName, final boolean restartConnector) {
+        assertProducesMessages(topicName, collectionName, restartConnector, 1);
+    }
+
+    private void assertProducesMessages(final String topicName, final String collectionName, final int partitionCount) {
+        assertProducesMessages(topicName, collectionName, false, partitionCount);
+    }
+
+    private void assertProducesMessages(final String topicName, final String collectionName, final boolean restartConnector,
+                                        final int partitionCount) {
 
         List<TweetMsg> tweets = IntStream.range(0, 100).mapToObj(i ->
                 TweetMsg.newBuilder().setId$1(i)
@@ -101,25 +189,77 @@ class MongoSinkConnectorTest extends MongoKafkaTestCase {
         producerProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, "io.confluent.kafka.serializers.KafkaAvroSerializer");
         producerProps.put(KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, KAFKA.schemaRegistryUrl());
 
-        try (KafkaProducer<String, TweetMsg> producer = new KafkaProducer<>(producerProps)) {
+        try (KafkaProducer<Long, TweetMsg> producer = new KafkaProducer<>(producerProps)) {
             producer.initTransactions();
             producer.beginTransaction();
-            tweets.stream().filter(t -> t.getId$1() < 50).forEach(tweet -> producer.send(new ProducerRecord<>(topicName, tweet)));
+            tweets.stream().filter(t -> t.getId$1() < 50)
+                    .forEach(tweet ->
+                            producer.send(new ProducerRecord<>(topicName, RANDOM.nextInt(partitionCount), tweet.getId$1(),  tweet)));
             producer.commitTransaction();
 
             assertProduced(50, topicName);
-            assertEquals(50, getCollection(collectionName).countDocuments(), collectionName);
+            assertEventuallyEquals(50L, () -> getCollection(collectionName).countDocuments(), collectionName);
 
             if (restartConnector) {
                 restartSinkConnector(topicName);
             }
 
             producer.beginTransaction();
-            tweets.stream().filter(t -> t.getId$1() >= 50).forEach(tweet -> producer.send(new ProducerRecord<>(topicName, tweet)));
+            tweets.stream().filter(t -> t.getId$1() >= 50)
+                    .forEach(tweet ->
+                            producer.send(new ProducerRecord<>(topicName, RANDOM.nextInt(partitionCount), tweet.getId$1(),  tweet)));
             producer.commitTransaction();
 
             assertProduced(100, topicName);
-            assertEquals(100, getCollection(collectionName).countDocuments());
+            assertEventuallyEquals(100L, () -> getCollection(collectionName).countDocuments(), collectionName);
+        }
+    }
+
+    <T> void assertEventuallyEquals(final T expected, final Supplier<T> action, final String msg) {
+        assertEventuallyEquals(expected, action, msg, 5, 1000);
+    }
+
+    <T> void assertEventuallyEquals(final T expected, final Supplier<T> action, final String msg, final int retries, final long timeoutMs) {
+        int counter = 0;
+        boolean hasError = true;
+        AssertionFailedError exception = null;
+        while (counter < retries && hasError) {
+            try {
+                counter++;
+                assertEquals(expected, action.get(), msg);
+                hasError = false;
+            } catch (AssertionFailedError e) {
+                LOGGER.debug("Failed assertion on attempt: {}", counter);
+                exception = e;
+                try {
+                    Thread.sleep(timeoutMs);
+                } catch (InterruptedException interruptedException) {
+                    // ignore
+                }
+            }
+        }
+        if (hasError && exception != null) {
+            throw exception;
+        }
+    }
+
+    private void assertCollectionOrder(final boolean exact) {
+        assertCollectionOrder(getCollectionName(), exact);
+    }
+
+    private void assertCollectionOrder(final String collectionName, final boolean exactOrdering) {
+        List<Long> expectedIdOrder = LongStream.range(0, 100).boxed().collect(Collectors.toList());
+        List<Long> idOrder = getCollection(collectionName).find().sort(Sorts.ascending("_id"))
+                .into(new ArrayList<>())
+                .stream()
+                .map(d -> d.getLong("id"))
+                .collect(Collectors.toList());
+
+        assertEquals(new HashSet<>(expectedIdOrder), new HashSet<>(idOrder), format("%s missing expected values.", collectionName));
+        if (exactOrdering) {
+            assertEquals(expectedIdOrder, idOrder, format("%s is out of order.", collectionName));
+        } else {
+            assertNotEquals(expectedIdOrder, idOrder, format("%s unexpectedly in order.", collectionName));
         }
     }
 }

--- a/src/integrationTest/java/com/mongodb/kafka/connect/avro/TweetMsg.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/avro/TweetMsg.java
@@ -29,7 +29,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
     private static final long serialVersionUID = -614364705592652792L;
     public static final org.apache.avro.Schema SCHEMA$ =
             new org.apache.avro.Schema.Parser().parse("{\"type\":\"record\",\"name\":\"TweetMsg\",\"namespace\":"
-                    + "\"com.mongodb.kafka.connect.data.avro\",\"fields\":[{\"name\":\"_id\",\"type\":\"long\"},"
+                    + "\"com.mongodb.kafka.connect.data.avro\",\"fields\":[{\"name\":\"id\",\"type\":\"long\"},"
                     + "{\"name\":\"text\",\"type\":{\"type\":\"string\",\"avro.java.string\":\"String\"}},"
                     + "{\"name\":\"hashtags\",\"type\":{\"type\":\"array\",\"items\":"
                     + "{\"type\":\"string\",\"avro.java.string\":\"String\"}}}]}");
@@ -72,7 +72,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
         return DECODER.decode(b);
     }
 
-    private long _id;
+    private long id;
     private java.lang.String text;
     private java.util.List<java.lang.String> hashtags;
 
@@ -86,12 +86,12 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
 
     /**
      * All-args constructor.
-     * @param _id The new value for _id
+     * @param id The new value for id
      * @param text The new value for text
      * @param hashtags The new value for hashtags
      */
-    public TweetMsg(java.lang.Long _id, java.lang.String text, java.util.List<java.lang.String> hashtags) {
-        this._id = _id;
+    public TweetMsg(java.lang.Long id, java.lang.String text, java.util.List<java.lang.String> hashtags) {
+        this.id = id;
         this.text = text;
         this.hashtags = hashtags;
     }
@@ -104,7 +104,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
     public java.lang.Object get(int field$) {
         switch (field$) {
             case 0:
-                return _id;
+                return id;
             case 1:
                 return text;
             case 2:
@@ -119,7 +119,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
     public void put(int field$, java.lang.Object value$) {
         switch (field$) {
             case 0:
-                _id = (java.lang.Long) value$;
+                id = (java.lang.Long) value$;
                 break;
             case 1:
                 text = (java.lang.String) value$;
@@ -133,19 +133,19 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
     }
 
     /**
-     * Gets the value of the '_id' field.
-     * @return The value of the '_id' field.
+     * Gets the value of the 'id' field.
+     * @return The value of the 'id' field.
      */
     public java.lang.Long getId$1() {
-        return _id;
+        return id;
     }
 
     /**
-     * Sets the value of the '_id' field.
+     * Sets the value of the 'id' field.
      * @param value the value to set.
      */
     public void setId$1(java.lang.Long value) {
-        this._id = value;
+        this.id = value;
     }
 
     /**
@@ -212,7 +212,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
     public static class Builder extends org.apache.avro.specific.SpecificRecordBuilderBase<TweetMsg>
             implements org.apache.avro.data.RecordBuilder<TweetMsg> {
 
-        private long _id;
+        private long id;
         private java.lang.String text;
         private java.util.List<java.lang.String> hashtags;
 
@@ -227,8 +227,8 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
          */
         private Builder(TweetMsg.Builder other) {
             super(other);
-            if (isValidValue(fields()[0], other._id)) {
-                this._id = data().deepCopy(fields()[0].schema(), other._id);
+            if (isValidValue(fields()[0], other.id)) {
+                this.id = data().deepCopy(fields()[0].schema(), other.id);
                 fieldSetFlags()[0] = true;
             }
             if (isValidValue(fields()[1], other.text)) {
@@ -247,8 +247,8 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
          */
         private Builder(TweetMsg other) {
             super(SCHEMA$);
-            if (isValidValue(fields()[0], other._id)) {
-                this._id = data().deepCopy(fields()[0].schema(), other._id);
+            if (isValidValue(fields()[0], other.id)) {
+                this.id = data().deepCopy(fields()[0].schema(), other.id);
                 fieldSetFlags()[0] = true;
             }
             if (isValidValue(fields()[1], other.text)) {
@@ -262,28 +262,28 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
         }
 
         /**
-         * Gets the value of the '_id' field.
+         * Gets the value of the 'id' field.
          * @return The value.
          */
         public java.lang.Long getId$1() {
-            return _id;
+            return id;
         }
 
         /**
-         * Sets the value of the '_id' field.
-         * @param value The value of '_id'.
+         * Sets the value of the 'id' field.
+         * @param value The value of 'id'.
          * @return This builder.
          */
         public TweetMsg.Builder setId$1(long value) {
             validate(fields()[0], value);
-            this._id = value;
+            this.id = value;
             fieldSetFlags()[0] = true;
             return this;
         }
 
         /**
-         * Checks whether the '_id' field has been set.
-         * @return True if the '_id' field has been set, false otherwise.
+         * Checks whether the 'id' field has been set.
+         * @return True if the 'id' field has been set, false otherwise.
          */
         public boolean hasId$1() {
             return fieldSetFlags()[0];
@@ -291,7 +291,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
 
 
         /**
-         * Clears the value of the '_id' field.
+         * Clears the value of the 'id' field.
          * @return This builder.
          */
         public TweetMsg.Builder clearId$1() {
@@ -382,7 +382,7 @@ public class TweetMsg extends org.apache.avro.specific.SpecificRecordBase implem
         public TweetMsg build() {
             try {
                 TweetMsg record = new TweetMsg();
-                record._id = fieldSetFlags()[0] ? this._id : (java.lang.Long) defaultValue(fields()[0]);
+                record.id = fieldSetFlags()[0] ? this.id : (java.lang.Long) defaultValue(fields()[0]);
                 record.text = fieldSetFlags()[1] ? this.text : (java.lang.String) defaultValue(fields()[1]);
                 record.hashtags = fieldSetFlags()[2] ? this.hashtags : (java.util.List<java.lang.String>) defaultValue(fields()[2]);
                 return record;

--- a/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoKafkaTestCase.java
+++ b/src/integrationTest/java/com/mongodb/kafka/connect/mongodb/MongoKafkaTestCase.java
@@ -51,7 +51,6 @@ import com.mongodb.kafka.connect.MongoSourceConnector;
 import com.mongodb.kafka.connect.embedded.EmbeddedKafka;
 import com.mongodb.kafka.connect.sink.MongoSinkConfig;
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
-import com.mongodb.kafka.connect.sink.processor.id.strategy.ProvidedInValueStrategy;
 import com.mongodb.kafka.connect.source.MongoSourceConfig;
 
 public class MongoKafkaTestCase {
@@ -64,7 +63,7 @@ public class MongoKafkaTestCase {
     public static final MongoDBHelper MONGODB = new MongoDBHelper();
 
     public String getTopicName() {
-        return  format("%s%s",  getCollection().getNamespace().getFullName(), POSTFIX.incrementAndGet());
+        return  format("%s%s",  getCollectionName(), POSTFIX.incrementAndGet());
     }
 
     public MongoClient getMongoClient() {
@@ -161,7 +160,6 @@ public class MongoKafkaTestCase {
         props.put(MongoSinkConfig.CONNECTION_URI_CONFIG, MONGODB.getConnectionString().toString());
         props.put(MongoSinkTopicConfig.DATABASE_CONFIG, MONGODB.getDatabaseName());
         props.put(MongoSinkTopicConfig.COLLECTION_CONFIG, getCollectionName());
-        props.put(MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG, ProvidedInValueStrategy.class.getName());
         props.put("key.converter", AvroConverter.class.getName());
         props.put("key.converter.schema.registry.url", KAFKA.schemaRegistryUrl());
         props.put("value.converter", AvroConverter.class.getName());

--- a/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
+++ b/src/main/java/com/mongodb/kafka/connect/MongoSinkConnector.java
@@ -22,8 +22,8 @@ import static com.mongodb.kafka.connect.util.ConnectionValidator.getConfigByName
 import static com.mongodb.kafka.connect.util.ConnectionValidator.validateCanConnect;
 import static com.mongodb.kafka.connect.util.ConnectionValidator.validateUserHasActions;
 import static java.util.Arrays.asList;
-import static java.util.Collections.singletonList;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -57,7 +57,11 @@ public class MongoSinkConnector extends SinkConnector {
 
     @Override
     public List<Map<String, String>> taskConfigs(final int maxTasks) {
-        return singletonList(settings);
+        ArrayList<Map<String, String>> configs = new ArrayList<>();
+        for (int i = 0; i < maxTasks; i++) {
+            configs.add(settings);
+        }
+        return configs;
     }
 
     @Override

--- a/src/test/java/com/mongodb/kafka/connect/MongoSinkConnnectorTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/MongoSinkConnnectorTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.IntStream;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -68,9 +69,9 @@ class MongoSinkConnnectorTest {
             put("b", "2");
         }};
         sinkConnector.start(configMap);
-        List<Map<String, String>> taskConfigs = sinkConnector.taskConfigs(100);
+        List<Map<String, String>> taskConfigs = sinkConnector.taskConfigs(10);
 
-        assertEquals(1, taskConfigs.size());
-        assertEquals(configMap, taskConfigs.get(0));
+        assertEquals(10, taskConfigs.size());
+        IntStream.range(0, 10).boxed().forEach(i -> assertEquals(configMap, taskConfigs.get(1)));
     }
 }


### PR DESCRIPTION
Kafka Connect provides built-in support for parallelism and scalable data copying
by assigning topic partitions to tasks. This allows for parallelism at the cost of
sequentially processing the data.

When using multiple tasks, data will be processeed out of order to the order of
the topic. Each task will be assigned partitions from a topic and these will be
processed independently of the other partitions.

KAFKA-92


https://evergreen.mongodb.com/version/5eba7949562343723be5ab62