### PR TITLE
Added AllowList and BlockList field projectors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
   - [KAFKA-118](https://jira.mongodb.org/browse/KAFKA-118) Made UuidStrategy configurable so can output BsonBinary Uuid values
   - [KAFKA-101](https://jira.mongodb.org/browse/KAFKA-101) Added `UuidProvidedInKeyStrategy` & `UuidProvidedInValueStrategy`
   - [KAFKA-114](https://jira.mongodb.org/browse/KAFKA-114) Added `UpdateOneBusinessKeyTimestampStrategy` write model strategy`
+  - [KAFKA-112](https://jira.mongodb.org/browse/KAFKA-112) Added `BlockList` and `AllowList` field projector type configurations and
+    `BlockListKeyProjector`, `BlockListValueProjector`, `AllowListKeyProjector`and `AllowListValueProjector` Post processors.
+    Deprecated: `BlacklistKeyProjector`, `BlacklistValueProjector`, `WhitelistKeyProjector` and `WhitelistValueProjector`.
 
 ## 1.1.0
   - [KAFKA-45](https://jira.mongodb.org/browse/KAFKA-45) Allow the Sink connector to ignore unused source record key or value fields.

--- a/src/main/java/com/mongodb/kafka/connect/sink/Configurable.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/Configurable.java
@@ -12,13 +12,10 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
  */
 
 package com.mongodb.kafka.connect.sink;
 
-import org.apache.kafka.common.config.AbstractConfig;
-
 public interface Configurable {
-  void configure(AbstractConfig configuration);
+  void configure(MongoSinkTopicConfig configuration);
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/AllowListKeyProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/AllowListKeyProjector.java
@@ -18,13 +18,19 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.ALLOWLIST;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_CONFIG;
+
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.processor.field.projection.AllowListProjector;
 
-/** @deprecated use {@link AllowListValueProjector} instead */
-@Deprecated
-public class WhitelistValueProjector extends AllowListValueProjector {
+public class AllowListKeyProjector extends AllowListProjector {
 
-  public WhitelistValueProjector(final MongoSinkTopicConfig config) {
-    super(config);
+  public AllowListKeyProjector(final MongoSinkTopicConfig config) {
+    this(config, config.getString(KEY_PROJECTION_LIST_CONFIG));
+  }
+
+  public AllowListKeyProjector(final MongoSinkTopicConfig config, final String fieldList) {
+    super(config, buildProjectionList(ALLOWLIST, fieldList), SinkDocumentField.KEY);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/AllowListValueProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/AllowListValueProjector.java
@@ -18,13 +18,19 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.ALLOWLIST;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
+
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.processor.field.projection.AllowListProjector;
 
-/** @deprecated use {@link AllowListValueProjector} instead */
-@Deprecated
-public class WhitelistValueProjector extends AllowListValueProjector {
+public class AllowListValueProjector extends AllowListProjector {
 
-  public WhitelistValueProjector(final MongoSinkTopicConfig config) {
-    super(config);
+  public AllowListValueProjector(final MongoSinkTopicConfig config) {
+    this(config, config.getString(VALUE_PROJECTION_LIST_CONFIG));
+  }
+
+  public AllowListValueProjector(final MongoSinkTopicConfig config, final String fieldList) {
+    super(config, buildProjectionList(ALLOWLIST, fieldList), SinkDocumentField.VALUE);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/BlacklistKeyProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/BlacklistKeyProjector.java
@@ -18,22 +18,13 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
-import org.apache.kafka.connect.sink.SinkRecord;
-
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
-import com.mongodb.kafka.connect.sink.converter.SinkDocument;
-import com.mongodb.kafka.connect.sink.processor.field.projection.BlacklistProjector;
 
-public class BlacklistKeyProjector extends BlacklistProjector {
+/** @deprecated Use {@link BlockListKeyProjector} instead */
+@Deprecated
+public class BlacklistKeyProjector extends BlockListKeyProjector {
 
   public BlacklistKeyProjector(final MongoSinkTopicConfig config) {
-    super(config, getKeyFields(config));
-  }
-
-  @Override
-  public void process(final SinkDocument doc, final SinkRecord orig) {
-    if (isUsingBlacklistKeyProjection()) {
-      doc.getKeyDoc().ifPresent(kd -> getFields().forEach(f -> doProjection(f, kd)));
-    }
+    super(config);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/BlacklistValueProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/BlacklistValueProjector.java
@@ -18,22 +18,13 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
-import org.apache.kafka.connect.sink.SinkRecord;
-
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
-import com.mongodb.kafka.connect.sink.converter.SinkDocument;
-import com.mongodb.kafka.connect.sink.processor.field.projection.BlacklistProjector;
 
-public class BlacklistValueProjector extends BlacklistProjector {
+/** @deprecated Use {@link BlockListValueProjector} instead */
+@Deprecated
+public class BlacklistValueProjector extends BlockListValueProjector {
 
   public BlacklistValueProjector(final MongoSinkTopicConfig config) {
-    super(config, getValueFields(config));
-  }
-
-  @Override
-  public void process(final SinkDocument doc, final SinkRecord orig) {
-    if (isUsingBlacklistValueProjection()) {
-      doc.getValueDoc().ifPresent(vd -> getFields().forEach(f -> doProjection(f, vd)));
-    }
+    super(config);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/BlockListKeyProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/BlockListKeyProjector.java
@@ -18,13 +18,19 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.BLOCKLIST;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_CONFIG;
+
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.processor.field.projection.BlockListProjector;
 
-/** @deprecated use {@link AllowListValueProjector} instead */
-@Deprecated
-public class WhitelistValueProjector extends AllowListValueProjector {
+public class BlockListKeyProjector extends BlockListProjector {
 
-  public WhitelistValueProjector(final MongoSinkTopicConfig config) {
-    super(config);
+  public BlockListKeyProjector(final MongoSinkTopicConfig config) {
+    this(config, config.getString(KEY_PROJECTION_LIST_CONFIG));
+  }
+
+  public BlockListKeyProjector(final MongoSinkTopicConfig config, final String fieldList) {
+    super(config, buildProjectionList(BLOCKLIST, fieldList), SinkDocumentField.KEY);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/BlockListValueProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/BlockListValueProjector.java
@@ -18,13 +18,19 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.BLOCKLIST;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
+
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.processor.field.projection.BlockListProjector;
 
-/** @deprecated use {@link AllowListValueProjector} instead */
-@Deprecated
-public class WhitelistValueProjector extends AllowListValueProjector {
+public class BlockListValueProjector extends BlockListProjector {
 
-  public WhitelistValueProjector(final MongoSinkTopicConfig config) {
-    super(config);
+  public BlockListValueProjector(final MongoSinkTopicConfig config) {
+    this(config, config.getString(VALUE_PROJECTION_LIST_CONFIG));
+  }
+
+  public BlockListValueProjector(final MongoSinkTopicConfig config, final String fieldList) {
+    super(config, buildProjectionList(BLOCKLIST, fieldList), SinkDocumentField.VALUE);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/WhitelistKeyProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/WhitelistKeyProjector.java
@@ -18,22 +18,13 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
-import org.apache.kafka.connect.sink.SinkRecord;
-
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
-import com.mongodb.kafka.connect.sink.converter.SinkDocument;
-import com.mongodb.kafka.connect.sink.processor.field.projection.WhitelistProjector;
 
-public class WhitelistKeyProjector extends WhitelistProjector {
+/** @deprecated use {@link AllowListKeyProjector} instead */
+@Deprecated
+public class WhitelistKeyProjector extends AllowListKeyProjector {
 
   public WhitelistKeyProjector(final MongoSinkTopicConfig config) {
-    super(config, getKeyFields(config));
-  }
-
-  @Override
-  public void process(final SinkDocument doc, final SinkRecord orig) {
-    if (isUsingWhitelistKeyProjection()) {
-      doc.getKeyDoc().ifPresent(kd -> doProjection("", kd));
-    }
+    super(config);
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/AllowListProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/AllowListProjector.java
@@ -12,15 +12,12 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
  */
 
 package com.mongodb.kafka.connect.sink.processor.field.projection;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.ALLOWLIST;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
 
 import java.util.Arrays;
 import java.util.Iterator;
@@ -33,22 +30,13 @@ import org.bson.BsonValue;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 
-public abstract class WhitelistProjector extends FieldProjector {
+public abstract class AllowListProjector extends FieldProjector {
 
-  public WhitelistProjector(final MongoSinkTopicConfig config, final Set<String> fields) {
-    super(config, fields);
-  }
-
-  protected boolean isUsingWhitelistKeyProjection() {
-    return getConfig()
-        .getString(KEY_PROJECTION_TYPE_CONFIG)
-        .equalsIgnoreCase(MongoSinkTopicConfig.FieldProjectionType.WHITELIST.name());
-  }
-
-  protected boolean isUsingWhitelistValueProjection() {
-    return getConfig()
-        .getString(VALUE_PROJECTION_TYPE_CONFIG)
-        .equalsIgnoreCase(MongoSinkTopicConfig.FieldProjectionType.WHITELIST.name());
+  public AllowListProjector(
+      final MongoSinkTopicConfig config,
+      final Set<String> fields,
+      final SinkDocumentField sinkDocumentField) {
+    super(config, fields, ALLOWLIST, sinkDocumentField);
   }
 
   @Override

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/BlockListProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/BlockListProjector.java
@@ -12,14 +12,11 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- *
- * Original Work: Apache License, Version 2.0, Copyright 2017 Hans-Peter Grahsl.
  */
-
 package com.mongodb.kafka.connect.sink.processor.field.projection;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.BLOCKLIST;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.ID_FIELD;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_CONFIG;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -31,22 +28,13 @@ import org.bson.BsonValue;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 
-public abstract class BlacklistProjector extends FieldProjector {
+public abstract class BlockListProjector extends FieldProjector {
 
-  public BlacklistProjector(final MongoSinkTopicConfig config, final Set<String> fields) {
-    super(config, fields);
-  }
-
-  protected boolean isUsingBlacklistKeyProjection() {
-    return getConfig()
-        .getString(KEY_PROJECTION_TYPE_CONFIG)
-        .equalsIgnoreCase(MongoSinkTopicConfig.FieldProjectionType.BLACKLIST.name());
-  }
-
-  protected boolean isUsingBlacklistValueProjection() {
-    return getConfig()
-        .getString(MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG)
-        .equalsIgnoreCase(MongoSinkTopicConfig.FieldProjectionType.BLACKLIST.name());
+  public BlockListProjector(
+      final MongoSinkTopicConfig config,
+      final Set<String> fields,
+      final SinkDocumentField sinkDocumentField) {
+    super(config, fields, BLOCKLIST, sinkDocumentField);
   }
 
   @Override

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/FieldProjector.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/field/projection/FieldProjector.java
@@ -17,22 +17,20 @@
  */
 package com.mongodb.kafka.connect.sink.processor.field.projection;
 
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_LIST_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.KEY_PROJECTION_TYPE_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
-import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
-
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import org.apache.kafka.common.config.AbstractConfig;
+import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.bson.BsonDocument;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType;
+import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 import com.mongodb.kafka.connect.sink.processor.PostProcessor;
 
 public abstract class FieldProjector extends PostProcessor {
@@ -42,56 +40,83 @@ public abstract class FieldProjector extends PostProcessor {
   static final String SUB_FIELD_DOT_SEPARATOR = ".";
 
   private final Set<String> fields;
+  private final FieldProjectionType fieldProjectionType;
+  private final SinkDocumentField sinkDocumentField;
 
-  public FieldProjector(final MongoSinkTopicConfig config, final Set<String> fields) {
+  public enum SinkDocumentField {
+    KEY,
+    VALUE
+  }
+
+  public FieldProjector(
+      final MongoSinkTopicConfig config,
+      final Set<String> fields,
+      final FieldProjectionType fieldProjectionType,
+      final SinkDocumentField sinkDocumentField) {
     super(config);
     this.fields = fields;
+    this.fieldProjectionType = fieldProjectionType;
+    this.sinkDocumentField = sinkDocumentField;
   }
 
   public Set<String> getFields() {
     return fields;
   }
 
+  @Override
+  public void process(final SinkDocument doc, final SinkRecord orig) {
+    switch (fieldProjectionType) {
+      case ALLOWLIST:
+        getDocumentToProcess(doc).ifPresent(vd -> doProjection("", vd));
+        break;
+      case BLOCKLIST:
+        getDocumentToProcess(doc).ifPresent(vd -> getFields().forEach(f -> doProjection(f, vd)));
+        break;
+      default:
+        // Do nothing
+    }
+  }
+
+  private Optional<BsonDocument> getDocumentToProcess(final SinkDocument sinkDocument) {
+    return sinkDocumentField == SinkDocumentField.KEY
+        ? sinkDocument.getKeyDoc()
+        : sinkDocument.getValueDoc();
+  }
+
   protected abstract void doProjection(String field, BsonDocument doc);
 
-  protected static Set<String> getKeyFields(final AbstractConfig config) {
-    return buildProjectionList(
-        config.getString(KEY_PROJECTION_TYPE_CONFIG), config.getString(KEY_PROJECTION_LIST_CONFIG));
-  }
+  public static Set<String> buildProjectionList(
+      final FieldProjectionType fieldProjectionType, final String fieldList) {
 
-  protected static Set<String> getValueFields(final AbstractConfig config) {
-    return buildProjectionList(
-        config.getString(VALUE_PROJECTION_TYPE_CONFIG),
-        config.getString(VALUE_PROJECTION_LIST_CONFIG));
-  }
+    Set<String> projectionList;
+    switch (fieldProjectionType) {
+      case BLOCKLIST:
+      case BLACKLIST:
+        projectionList = new HashSet<>(toList(fieldList));
+        break;
+      case ALLOWLIST:
+      case WHITELIST:
+        // NOTE: for sub document notation all left prefix bound paths are created
+        // which allows for easy recursion mechanism to whitelist nested doc fields
 
-  private static Set<String> buildProjectionList(
-      final String projectionType, final String fieldList) {
-    if (projectionType.equalsIgnoreCase(
-        MongoSinkTopicConfig.FieldProjectionType.BLACKLIST.name())) {
-      return new HashSet<>(toList(fieldList));
-    } else if (projectionType.equalsIgnoreCase(
-        MongoSinkTopicConfig.FieldProjectionType.WHITELIST.name())) {
-      // NOTE: for sub document notation all left prefix bound paths are created
-      // which allows for easy recursion mechanism to whitelist nested doc fields
+        projectionList = new HashSet<>();
+        List<String> fields = toList(fieldList);
 
-      HashSet<String> whitelistExpanded = new HashSet<>();
-      List<String> fields = toList(fieldList);
-
-      for (String f : fields) {
-        String entry = f;
-        whitelistExpanded.add(entry);
-        while (entry.contains(".")) {
-          entry = entry.substring(0, entry.lastIndexOf("."));
-          if (!entry.isEmpty()) {
-            whitelistExpanded.add(entry);
+        for (String f : fields) {
+          String entry = f;
+          projectionList.add(entry);
+          while (entry.contains(".")) {
+            entry = entry.substring(0, entry.lastIndexOf("."));
+            if (!entry.isEmpty()) {
+              projectionList.add(entry);
+            }
           }
         }
-      }
-      return whitelistExpanded;
-    } else {
-      return new HashSet<>();
+        break;
+      default:
+        projectionList = new HashSet<>();
     }
+    return projectionList;
   }
 
   private static List<String> toList(final String value) {

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategy.java
@@ -22,9 +22,14 @@ import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.bson.BsonValue;
 
+import com.mongodb.kafka.connect.sink.Configurable;
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
-public interface IdStrategy {
+public interface IdStrategy extends Configurable {
 
   BsonValue generateId(SinkDocument doc, SinkRecord orig);
+
+  @Override
+  default void configure(final MongoSinkTopicConfig configuration) {}
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidStrategy.java
@@ -22,7 +22,6 @@ import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_ST
 
 import java.util.UUID;
 
-import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.connect.sink.SinkRecord;
 
 import org.bson.BsonBinary;
@@ -30,11 +29,10 @@ import org.bson.BsonString;
 import org.bson.BsonValue;
 import org.bson.UuidRepresentation;
 
-import com.mongodb.kafka.connect.sink.Configurable;
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
-public class UuidStrategy implements IdStrategy, Configurable {
+public class UuidStrategy implements IdStrategy {
   private MongoSinkTopicConfig.UuidBsonFormat outputFormat;
 
   @Override
@@ -48,7 +46,7 @@ public class UuidStrategy implements IdStrategy, Configurable {
   }
 
   @Override
-  public void configure(final AbstractConfig configuration) {
+  public void configure(final MongoSinkTopicConfig configuration) {
     outputFormat =
         MongoSinkTopicConfig.UuidBsonFormat.valueOf(
             configuration.getString(DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG).toUpperCase());


### PR DESCRIPTION
Deprecated: `Blacklist[Key|Value]Projector`, `Whitelist[Key|Value]Projector`.
Use: `BlockListKeyProjector`, `BlockListValueProjector`,
     `AllowListKeyProjector` or `AllowListValueProjector` instead.

KAFKA-112


https://spruce.mongodb.com/version/5ef488ba1e2d17462acfb4a8/tasks