### PR TITLE
Add specific configurations for Partial[Key|Value]Strategies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   - [KAFKA-112](https://jira.mongodb.org/browse/KAFKA-112) Added `BlockList` and `AllowList` field projector type configurations and
     `BlockListKeyProjector`, `BlockListValueProjector`, `AllowListKeyProjector`and `AllowListValueProjector` Post processors.
     Deprecated: `BlacklistKeyProjector`, `BlacklistValueProjector`, `WhitelistKeyProjector` and `WhitelistValueProjector`.
+  - [KAFKA-75](https://jira.mongodb.org/browse/KAFKA-75) Added specific configuration for the id strategies: `ProvidedInKeyStrategy` and `ProvidedInValueStrategy`.
+    Added `document.id.strategy.partial.value.projection.type`, `document.id.strategy.partial.value.projection.list`,
+    `document.id.strategy.partial.key.projection.type` and `document.id.strategy.partial.key.projection.list`.
 
 ## 1.1.0
   - [KAFKA-45](https://jira.mongodb.org/browse/KAFKA-45) Allow the Sink connector to ignore unused source record key or value fields.

--- a/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/MongoSinkTopicConfig.java
@@ -116,12 +116,49 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   private static final String DOCUMENT_ID_STRATEGY_UUID_FORMAT_DISPLAY =
       "The document id strategy uuid format";
   private static final String DOCUMENT_ID_STRATEGY_UUID_FORMAT_DOC =
-      "The bson output format when using the `UuidStrategy`.";
+      "The bson output format when using the `UuidStrategy`. " + "Either `String` or `Binary`.";
   private static final String DOCUMENT_ID_STRATEGY_UUID_FORMAT_DEFAULT = "string";
+
+  public static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_CONFIG =
+      "document.id.strategy.partial.key.projection.type";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_DISPLAY =
+      "The document id strategy key projection";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_DOC =
+      "For use with the `PartialKeyStrategy` allows custom key fields to be projected for the id strategy "
+          + "Use either `AllowList` or `BlockList`.";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_DEFAULT = "";
+
+  public static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_CONFIG =
+      "document.id.strategy.partial.key.projection.list";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_DISPLAY =
+      "The document id strategy key projection list";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_DOC =
+      "For use with the `PartialKeyStrategy` allows custom key fields to be projected for the id strategy. "
+          + "A comma separated list of field names for key projection.";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_DEFAULT = "";
+
+  public static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG =
+      "document.id.strategy.partial.value.projection.type";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_DISPLAY =
+      "The document id strategy value projection";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_DOC =
+      "For use with the `PartialValueStrategy` allows custom value fields to be projected for the id strategy. "
+          + "Use either `AllowList` or `BlockList`.";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_DEFAULT = "";
+
+  public static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG =
+      "document.id.strategy.partial.value.projection.list";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_DISPLAY =
+      "The document id strategy value projection list";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_DOC =
+      "For use with the `PartialValueStrategy` allows custom value fields to be projected for the id strategy. "
+          + "A comma separated list of field names for value projection.";
+  private static final String DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_DEFAULT = "";
 
   public static final String KEY_PROJECTION_TYPE_CONFIG = "key.projection.type";
   private static final String KEY_PROJECTION_TYPE_DISPLAY = "The key projection type";
-  private static final String KEY_PROJECTION_TYPE_DOC = "The type of key projection to use";
+  private static final String KEY_PROJECTION_TYPE_DOC =
+      "The type of key projection to use " + "Use either `AllowList` or `BlockList`.";
   private static final String KEY_PROJECTION_TYPE_DEFAULT = "none";
 
   public static final String KEY_PROJECTION_LIST_CONFIG = "key.projection.list";
@@ -131,7 +168,8 @@ public class MongoSinkTopicConfig extends AbstractConfig {
   private static final String KEY_PROJECTION_LIST_DEFAULT = "";
 
   public static final String VALUE_PROJECTION_TYPE_CONFIG = "value.projection.type";
-  private static final String VALUE_PROJECTION_TYPE_DISPLAY = "The type of value projection to use";
+  private static final String VALUE_PROJECTION_TYPE_DISPLAY =
+      "The type of value projection to use " + "Use either `AllowList` or `BlockList`.";
   private static final String VALUE_PROJECTION_TYPE_DOC = "The type of value projection to use";
   private static final String VALUE_PROJECTION_TYPE_DEFAULT = "none";
 
@@ -702,6 +740,58 @@ public class MongoSinkTopicConfig extends AbstractConfig {
         ConfigDef.Width.MEDIUM,
         DOCUMENT_ID_STRATEGY_UUID_FORMAT_DISPLAY,
         Validators.EnumValidatorAndRecommender.in(UuidBsonFormat.values()));
+
+    configDef.define(
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_CONFIG,
+        ConfigDef.Type.STRING,
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_DEFAULT,
+        Validators.emptyString()
+            .or(Validators.EnumValidatorAndRecommender.in(FieldProjectionType.values())),
+        ConfigDef.Importance.LOW,
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_DISPLAY,
+        Validators.EnumValidatorAndRecommender.in(FieldProjectionType.values()));
+
+    configDef.define(
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_CONFIG,
+        ConfigDef.Type.STRING,
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_DEFAULT,
+        ConfigDef.Importance.LOW,
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_DISPLAY,
+        singletonList(DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_CONFIG));
+
+    configDef.define(
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG,
+        ConfigDef.Type.STRING,
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_DEFAULT,
+        Validators.emptyString()
+            .or(Validators.EnumValidatorAndRecommender.in(FieldProjectionType.values())),
+        ConfigDef.Importance.LOW,
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_DISPLAY,
+        Validators.EnumValidatorAndRecommender.in(FieldProjectionType.values()));
+
+    configDef.define(
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG,
+        ConfigDef.Type.STRING,
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_DEFAULT,
+        ConfigDef.Importance.LOW,
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_DISPLAY,
+        singletonList(DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG));
 
     group = "Change Data Capture";
     orderInGroup = 0;

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/PartialValueStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/PartialValueStrategy.java
@@ -19,10 +19,13 @@
 package com.mongodb.kafka.connect.sink.processor.id.strategy;
 
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.ALLOWLIST;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.BLOCKLIST;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_LIST_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.VALUE_PROJECTION_TYPE_CONFIG;
+import static com.mongodb.kafka.connect.util.ConfigHelper.getOverrideOrDefault;
 import static java.lang.String.format;
 
 import org.apache.kafka.connect.sink.SinkRecord;
@@ -39,6 +42,7 @@ import com.mongodb.kafka.connect.sink.processor.field.projection.FieldProjector;
 import com.mongodb.kafka.connect.util.ConnectConfigException;
 
 public class PartialValueStrategy implements IdStrategy {
+
   private FieldProjector fieldProjector;
 
   public PartialValueStrategy() {}
@@ -62,9 +66,17 @@ public class PartialValueStrategy implements IdStrategy {
   @Override
   public void configure(final MongoSinkTopicConfig config) {
     FieldProjectionType valueProjectionType =
-        FieldProjectionType.valueOf(config.getString(VALUE_PROJECTION_TYPE_CONFIG).toUpperCase());
-
-    String fieldList = config.getString(VALUE_PROJECTION_LIST_CONFIG);
+        FieldProjectionType.valueOf(
+            getOverrideOrDefault(
+                    config,
+                    DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG,
+                    VALUE_PROJECTION_TYPE_CONFIG)
+                .toUpperCase());
+    String fieldList =
+        getOverrideOrDefault(
+            config,
+            DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG,
+            VALUE_PROJECTION_LIST_CONFIG);
 
     switch (valueProjectionType) {
       case BLACKLIST:

--- a/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidStrategy.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/processor/id/strategy/UuidStrategy.java
@@ -30,15 +30,16 @@ import org.bson.BsonValue;
 import org.bson.UuidRepresentation;
 
 import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
+import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.UuidBsonFormat;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 public class UuidStrategy implements IdStrategy {
-  private MongoSinkTopicConfig.UuidBsonFormat outputFormat;
+  private UuidBsonFormat outputFormat;
 
   @Override
   public BsonValue generateId(final SinkDocument doc, final SinkRecord orig) {
     UUID uuid = UUID.randomUUID();
-    if (outputFormat.equals(MongoSinkTopicConfig.UuidBsonFormat.STRING)) {
+    if (outputFormat.equals(UuidBsonFormat.STRING)) {
       return new BsonString(uuid.toString());
     }
 
@@ -48,7 +49,7 @@ public class UuidStrategy implements IdStrategy {
   @Override
   public void configure(final MongoSinkTopicConfig configuration) {
     outputFormat =
-        MongoSinkTopicConfig.UuidBsonFormat.valueOf(
+        UuidBsonFormat.valueOf(
             configuration.getString(DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG).toUpperCase());
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
+++ b/src/main/java/com/mongodb/kafka/connect/util/ConfigHelper.java
@@ -20,6 +20,7 @@ import static java.lang.String.format;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.kafka.common.config.AbstractConfig;
 import org.apache.kafka.common.config.ConfigException;
 
 import org.bson.Document;
@@ -104,5 +105,14 @@ public final class ConfigHelper {
         .driverName(format("%s|%s", Versions.NAME, type))
         .driverVersion(Versions.VERSION)
         .build();
+  }
+
+  public static String getOverrideOrDefault(
+      final AbstractConfig config, final String overrideConfig, final String defaultConfig) {
+    String stringConfig = config.getString(overrideConfig);
+    if (stringConfig.isEmpty()) {
+      stringConfig = config.getString(defaultConfig);
+    }
+    return stringConfig;
   }
 }

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/DocumentIdAdderTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/DocumentIdAdderTest.java
@@ -18,6 +18,7 @@
 
 package com.mongodb.kafka.connect.sink.processor;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG;
 import static com.mongodb.kafka.connect.sink.SinkTestHelper.createTopicConfig;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -31,7 +32,6 @@ import org.junit.runner.RunWith;
 
 import org.bson.BsonDocument;
 
-import com.mongodb.kafka.connect.sink.MongoSinkTopicConfig;
 import com.mongodb.kafka.connect.sink.converter.SinkDocument;
 
 @RunWith(JUnitPlatform.class)
@@ -75,9 +75,7 @@ class DocumentIdAdderTest {
         sinkDocWithValueDoc.getValueDoc().orElseGet(BsonDocument::new).get("_id").isInt32(),
         "default id strategy ignores existing _id values");
 
-    new DocumentIdAdder(
-            createTopicConfig(
-                MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG, "true"))
+    new DocumentIdAdder(createTopicConfig(DOCUMENT_ID_STRATEGY_OVERWRITE_EXISTING_CONFIG, "true"))
         .process(sinkDocWithValueDoc, null);
 
     assertTrue(

--- a/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/sink/processor/id/strategy/IdStrategyTest.java
@@ -18,6 +18,10 @@
 
 package com.mongodb.kafka.connect.sink.processor.id.strategy;
 
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG;
+import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.DOCUMENT_ID_STRATEGY_UUID_FORMAT_CONFIG;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.ALLOWLIST;
 import static com.mongodb.kafka.connect.sink.MongoSinkTopicConfig.FieldProjectionType.BLACKLIST;
@@ -279,7 +283,9 @@ class IdStrategyTest {
         createTopicConfig(
             format(
                 "{'%s': '%s', '%s': 'keyPart1'}",
-                KEY_PROJECTION_TYPE_CONFIG, BLOCKLIST, KEY_PROJECTION_LIST_CONFIG));
+                DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_CONFIG,
+                BLOCKLIST,
+                DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_CONFIG));
 
     IdStrategy ids = new PartialKeyStrategy();
     ids.configure(cfg);
@@ -303,7 +309,9 @@ class IdStrategyTest {
         createTopicConfig(
             format(
                 "{'%s': '%s', '%s': 'keyPart1'}",
-                KEY_PROJECTION_TYPE_CONFIG, ALLOWLIST, KEY_PROJECTION_LIST_CONFIG));
+                DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_TYPE_CONFIG,
+                ALLOWLIST,
+                DOCUMENT_ID_STRATEGY_PARTIAL_KEY_PROJECTION_LIST_CONFIG));
 
     IdStrategy ids = new PartialKeyStrategy();
     ids.configure(cfg);
@@ -328,7 +336,9 @@ class IdStrategyTest {
         createTopicConfig(
             format(
                 "{'%s': '%s', '%s': 'valuePart1'}",
-                VALUE_PROJECTION_TYPE_CONFIG, BLOCKLIST, VALUE_PROJECTION_LIST_CONFIG));
+                DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG,
+                BLOCKLIST,
+                DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG));
 
     IdStrategy ids = new PartialValueStrategy();
     ids.configure(cfg);
@@ -353,7 +363,9 @@ class IdStrategyTest {
         createTopicConfig(
             format(
                 "{'%s': '%s', '%s': 'valuePart1'}",
-                VALUE_PROJECTION_TYPE_CONFIG, ALLOWLIST, VALUE_PROJECTION_LIST_CONFIG));
+                DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_TYPE_CONFIG,
+                ALLOWLIST,
+                DOCUMENT_ID_STRATEGY_PARTIAL_VALUE_PROJECTION_LIST_CONFIG));
 
     IdStrategy ids = new PartialValueStrategy();
     ids.configure(cfg);


### PR DESCRIPTION
Added `document.id.strategy.partial.key.` configurations and
`document.id.strategy.partial.value.` configurations.

So that users can both project fields as part of the Id Strategy
as well as project any fields they want to store.

https://spruce.mongodb.com/version/5ef4b937850e6113d2e0bbc2/tasks

KAFKA-75