### PR TITLE
Added support for Bson bytes in the Sink connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Changelog
 
+## 1.3.0
+  - [KAFKA-129](https://jira.mongodb.org/browse/KAFKA-129) Added support for Bson bytes in the Sink connector.
+
 ## 1.2.0
   - [KAFKA-92](https://jira.mongodb.org/browse/KAFKA-92) Allow the Sink connector to use multiple tasks.
   - [KAFKA-116](https://jira.mongodb.org/browse/KAFKA-116) Ensure the MongoCopyDataManager doesn't fail when the source is a non-existent database.

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/ByteArrayRecordConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/ByteArrayRecordConverter.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.sink.converter;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.errors.DataException;
+
+import org.bson.BsonDocument;
+import org.bson.RawBsonDocument;
+
+/** Used for converting Bson byte arrays */
+class ByteArrayRecordConverter implements RecordConverter {
+
+  @Override
+  public BsonDocument convert(final Schema schema, final Object value) {
+    if (value == null) {
+      throw new DataException("Error: value was null for BSON conversion");
+    }
+
+    return new RawBsonDocument((byte[]) value);
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/MapRecordConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/MapRecordConverter.java
@@ -25,12 +25,11 @@ import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BsonDocument;
 import org.bson.Document;
-import org.bson.codecs.configuration.CodecRegistry;
 
 import com.mongodb.MongoClientSettings;
 
-class JsonSchemalessRecordConverter implements RecordConverter {
-  private CodecRegistry codecRegistry = MongoClientSettings.getDefaultCodecRegistry();
+/** Used for converting Maps eg. Schemaless Json */
+class MapRecordConverter implements RecordConverter {
 
   @SuppressWarnings({"unchecked"})
   @Override
@@ -38,6 +37,7 @@ class JsonSchemalessRecordConverter implements RecordConverter {
     if (value == null) {
       throw new DataException("Error: value was null for JSON conversion");
     }
-    return new Document((Map<String, Object>) value).toBsonDocument(null, codecRegistry);
+    return new Document((Map<String, Object>) value)
+        .toBsonDocument(Document.class, MongoClientSettings.getDefaultCodecRegistry());
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/SchemaRecordConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/SchemaRecordConverter.java
@@ -22,7 +22,6 @@ import static java.util.Arrays.asList;
 import static java.util.Collections.unmodifiableSet;
 import static org.apache.kafka.connect.data.Schema.Type.ARRAY;
 import static org.apache.kafka.connect.data.Schema.Type.MAP;
-import static org.apache.kafka.connect.data.Schema.Type.STRUCT;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -62,12 +61,9 @@ import com.mongodb.kafka.connect.sink.converter.types.sink.bson.logical.DecimalF
 import com.mongodb.kafka.connect.sink.converter.types.sink.bson.logical.TimeFieldConverter;
 import com.mongodb.kafka.connect.sink.converter.types.sink.bson.logical.TimestampFieldConverter;
 
-// looks like Avro and JSON + Schema is convertible by means of
-// a unified conversion approach since they are using the
-// same the Struct/Type information ...
-class AvroJsonSchemafulRecordConverter implements RecordConverter {
-  private static final Logger LOGGER =
-      LoggerFactory.getLogger(AvroJsonSchemafulRecordConverter.class);
+/** Used for converting Struct based data eg. Avro or JSON with schema */
+class SchemaRecordConverter implements RecordConverter {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SchemaRecordConverter.class);
   private static final Set<String> LOGICAL_TYPE_NAMES =
       unmodifiableSet(
           new HashSet<>(
@@ -80,7 +76,7 @@ class AvroJsonSchemafulRecordConverter implements RecordConverter {
   private final Map<Schema.Type, SinkFieldConverter> converters = new HashMap<>();
   private final Map<String, SinkFieldConverter> logicalConverters = new HashMap<>();
 
-  AvroJsonSchemafulRecordConverter() {
+  SchemaRecordConverter() {
     // standard types
     registerSinkFieldConverter(new BooleanFieldConverter());
     registerSinkFieldConverter(new Int8FieldConverter());

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/SinkConverter.java
@@ -31,10 +31,10 @@ import org.bson.BsonDocument;
 
 public class SinkConverter {
   private static final Logger LOGGER = LoggerFactory.getLogger(SinkConverter.class);
-
-  private final RecordConverter schemafulConverter = new AvroJsonSchemafulRecordConverter();
-  private final RecordConverter schemalessConverter = new JsonSchemalessRecordConverter();
-  private final RecordConverter rawConverter = new JsonRawStringRecordConverter();
+  private static final RecordConverter SCHEMA_RECORD_CONVERTER = new SchemaRecordConverter();
+  private static final RecordConverter MAP_RECORD_CONVERTER = new MapRecordConverter();
+  private static final RecordConverter STRING_RECORD_CONVERTER = new StringRecordConverter();
+  private static final RecordConverter BYTE_ARRAY_RECORD_CONVERTER = new ByteArrayRecordConverter();
 
   public SinkDocument convert(final SinkRecord record) {
     LOGGER.debug(record.toString());
@@ -64,22 +64,28 @@ public class SinkConverter {
     // AVRO or JSON with schema
     if (schema != null && data instanceof Struct) {
       LOGGER.debug("using schemaful converter");
-      return schemafulConverter;
+      return SCHEMA_RECORD_CONVERTER;
     }
 
     // structured JSON without schema
     if (data instanceof Map) {
       LOGGER.debug("using schemaless converter");
-      return schemalessConverter;
+      return MAP_RECORD_CONVERTER;
     }
 
     // raw JSON string
     if (data instanceof String) {
       LOGGER.debug("using raw converter");
-      return rawConverter;
+      return STRING_RECORD_CONVERTER;
+    }
+
+    // raw Bson bytes
+    if (data instanceof byte[]) {
+      LOGGER.debug("using bson converter");
+      return BYTE_ARRAY_RECORD_CONVERTER;
     }
 
     throw new DataException(
-        "Error: no converter present due to unexpected object type " + data.getClass().getName());
+        "Error: No converter present due to unexpected object type: " + data.getClass().getName());
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/sink/converter/StringRecordConverter.java
+++ b/src/main/java/com/mongodb/kafka/connect/sink/converter/StringRecordConverter.java
@@ -23,7 +23,8 @@ import org.apache.kafka.connect.errors.DataException;
 
 import org.bson.BsonDocument;
 
-class JsonRawStringRecordConverter implements RecordConverter {
+/** Used for converting Json Raw Strings */
+class StringRecordConverter implements RecordConverter {
 
   @Override
   public BsonDocument convert(final Schema schema, final Object value) {


### PR DESCRIPTION
KAFKA-129

I took the opportunity to rename some classes and variables to be explicit about what type of data they hold / or convert.

https://spruce.mongodb.com/version/5f0ed6b4d6d80a42f103abb6/tasks