### PR TITLE
Added support for creating Bson bytes data in the Source connector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## 1.3.0
   - [KAFKA-129](https://jira.mongodb.org/browse/KAFKA-129) Added support for Bson bytes in the Sink connector.
+  - [KAFKA-122](https://jira.mongodb.org/browse/KAFKA-12) Added support for creating Bson bytes data in the Source connector.
 
 ## 1.2.0
   - [KAFKA-92](https://jira.mongodb.org/browse/KAFKA-92) Allow the Sink connector to use multiple tasks.

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoCopyDataManager.java
@@ -37,6 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.bson.BsonDocument;
+import org.bson.RawBsonDocument;
 import org.bson.conversions.Bson;
 
 import com.mongodb.MongoNamespace;
@@ -123,7 +124,7 @@ class MongoCopyDataManager implements AutoCloseable {
     try {
       mongoClient
           .getDatabase(namespace.getDatabaseName())
-          .getCollection(namespace.getCollectionName(), BsonDocument.class)
+          .getCollection(namespace.getCollectionName(), RawBsonDocument.class)
           .aggregate(createPipeline(namespace))
           .forEach((Consumer<? super BsonDocument>) this::putToQueue);
       namespacesToCopy.decrementAndGet();

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceConfig.java
@@ -57,6 +57,22 @@ public class MongoSourceConfig extends AbstractConfig {
       "The connection URI as supported by the official drivers. "
           + "eg: ``mongodb://user@pass@locahost/``.";
 
+  public static final String OUTPUT_FORMAT_KEY_CONFIG = "output.format.key";
+  private static final String OUTPUT_FORMAT_KEY_DEFAULT = OutputFormat.JSON.name().toLowerCase();
+  private static final String OUTPUT_FORMAT_KEY_DISPLAY = "The key output format";
+  private static final String OUTPUT_FORMAT_KEY_DOC =
+      "The output format of the data produced by the connector for the key. Supported formats are:\n"
+          + " * `json` - Raw Json strings\n"
+          + " * `bson` - Bson byte array\n";
+
+  public static final String OUTPUT_FORMAT_VALUE_CONFIG = "output.format.value";
+  private static final String OUTPUT_FORMAT_VALUE_DEFAULT = OutputFormat.JSON.name().toLowerCase();
+  private static final String OUTPUT_FORMAT_VALUE_DISPLAY = "The value output format";
+  private static final String OUTPUT_FORMAT_VALUE_DOC =
+      "The output format of the data produced by the connector for the value. Supported formats are:\n"
+          + " * `json` - Raw Json strings\n"
+          + " * `bson` - Bson byte array\n";
+
   public static final String TOPIC_PREFIX_CONFIG = "topic.prefix";
   private static final String TOPIC_PREFIX_DOC =
       "Prefix to prepend to database & collection names to generate the name of the Kafka "
@@ -156,6 +172,11 @@ public class MongoSourceConfig extends AbstractConfig {
   private static final List<Consumer<MongoSourceConfig>> INITIALIZERS =
       singletonList(MongoSourceConfig::validateCollection);
 
+  public enum OutputFormat {
+    JSON,
+    BSON
+  }
+
   private final ConnectionString connectionString;
 
   public MongoSourceConfig(final Map<?, ?> originals) {
@@ -173,6 +194,14 @@ public class MongoSourceConfig extends AbstractConfig {
 
   public ConnectionString getConnectionString() {
     return connectionString;
+  }
+
+  public OutputFormat getKeyOutputFormat() {
+    return OutputFormat.valueOf(getString(OUTPUT_FORMAT_KEY_CONFIG).toUpperCase());
+  }
+
+  public OutputFormat getValueOutputFormat() {
+    return OutputFormat.valueOf(getString(OUTPUT_FORMAT_VALUE_CONFIG).toUpperCase());
   }
 
   public Optional<List<Document>> getPipeline() {
@@ -243,6 +272,32 @@ public class MongoSourceConfig extends AbstractConfig {
         ++orderInGroup,
         Width.MEDIUM,
         CONNECTION_URI_DISPLAY);
+
+    configDef.define(
+        OUTPUT_FORMAT_KEY_CONFIG,
+        ConfigDef.Type.STRING,
+        OUTPUT_FORMAT_KEY_DEFAULT,
+        Validators.EnumValidatorAndRecommender.in(OutputFormat.values()),
+        ConfigDef.Importance.HIGH,
+        OUTPUT_FORMAT_KEY_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        OUTPUT_FORMAT_KEY_DISPLAY,
+        Validators.EnumValidatorAndRecommender.in(OutputFormat.values()));
+
+    configDef.define(
+        OUTPUT_FORMAT_VALUE_CONFIG,
+        ConfigDef.Type.STRING,
+        OUTPUT_FORMAT_VALUE_DEFAULT,
+        Validators.EnumValidatorAndRecommender.in(OutputFormat.values()),
+        ConfigDef.Importance.HIGH,
+        OUTPUT_FORMAT_VALUE_DOC,
+        group,
+        ++orderInGroup,
+        ConfigDef.Width.MEDIUM,
+        OUTPUT_FORMAT_VALUE_DISPLAY,
+        Validators.EnumValidatorAndRecommender.in(OutputFormat.values()));
 
     configDef.define(
         COPY_EXISTING_CONFIG,

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -24,6 +24,8 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PUBLISH_FULL_DOCUMENT_ONLY_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.TOPIC_PREFIX_CONFIG;
+import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.BSON_SCHEMA_AND_VALUE_PRODUCER;
+import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.RAW_JSON_STRING_SCHEMA_AND_VALUE_PRODUCER;
 import static com.mongodb.kafka.connect.util.ConfigHelper.getMongoDriverInformation;
 import static java.lang.String.format;
 import static java.util.Collections.singletonMap;
@@ -37,7 +39,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
-import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
@@ -60,6 +62,7 @@ import com.mongodb.client.MongoDatabase;
 import com.mongodb.client.model.changestream.ChangeStreamDocument;
 
 import com.mongodb.kafka.connect.Versions;
+import com.mongodb.kafka.connect.source.MongoSourceConfig.OutputFormat;
 
 /**
  * A Kafka Connect source task that uses change streams to broadcast changes to the collection,
@@ -189,29 +192,35 @@ public class MongoSourceTask extends SourceTask {
             getTopicNameFromNamespace(
                 prefix, changeStreamDocument.getDocument("ns", new BsonDocument()));
 
-        Optional<String> jsonDocument = Optional.empty();
+        Optional<BsonDocument> valueDocument = Optional.empty();
         if (publishFullDocumentOnly) {
           if (changeStreamDocument.containsKey(FULL_DOCUMENT)) {
-            jsonDocument = Optional.of(changeStreamDocument.getDocument(FULL_DOCUMENT).toJson());
+            valueDocument = Optional.of(changeStreamDocument.getDocument(FULL_DOCUMENT));
           }
         } else {
-          jsonDocument = Optional.of(changeStreamDocument.toJson());
+          valueDocument = Optional.of(changeStreamDocument);
         }
 
-        jsonDocument.ifPresent(
-            (json) -> {
-              LOGGER.trace("Adding {} to {}: {}", json, topicName, sourceOffset);
-              String keyJson =
-                  new BsonDocument(ID_FIELD, changeStreamDocument.get(ID_FIELD)).toJson();
+        valueDocument.ifPresent(
+            (valueDoc) -> {
+              LOGGER.trace("Adding {} to {}: {}", valueDoc, topicName, sourceOffset);
+              BsonDocument keyDocument =
+                  new BsonDocument(ID_FIELD, changeStreamDocument.get(ID_FIELD));
+
+              SchemaAndValue keySchemaAndValue =
+                  getSchemaAndValue(sourceConfig.getKeyOutputFormat(), keyDocument);
+              SchemaAndValue valueSchemaAndValue =
+                  getSchemaAndValue(sourceConfig.getValueOutputFormat(), valueDoc);
+
               sourceRecords.add(
                   new SourceRecord(
                       partition,
                       sourceOffset,
                       topicName,
-                      Schema.STRING_SCHEMA,
-                      keyJson,
-                      Schema.STRING_SCHEMA,
-                      json));
+                      keySchemaAndValue.schema(),
+                      keySchemaAndValue.value(),
+                      valueSchemaAndValue.schema(),
+                      valueSchemaAndValue.value()));
             });
 
         if (sourceRecords.size() == maxBatchSize) {
@@ -299,6 +308,18 @@ public class MongoSourceTask extends SourceTask {
           e.getErrorMessage(),
           e.getErrorCode());
       return null;
+    }
+  }
+
+  SchemaAndValue getSchemaAndValue(final OutputFormat outputFormat, final BsonDocument value) {
+    switch (outputFormat) {
+      case JSON:
+        return RAW_JSON_STRING_SCHEMA_AND_VALUE_PRODUCER.create(sourceConfig, value);
+      case BSON:
+        return BSON_SCHEMA_AND_VALUE_PRODUCER.create(sourceConfig, value);
+      default:
+        throw new ConnectException(
+            "Unsupported key output format" + sourceConfig.getKeyOutputFormat());
     }
   }
 

--- a/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/MongoSourceTask.java
@@ -119,7 +119,7 @@ public class MongoSourceTask extends SourceTask {
   private BsonDocument cachedResult;
   private BsonDocument cachedResumeToken;
 
-  private MongoCursor<BsonDocument> cursor;
+  private MongoCursor<? extends BsonDocument> cursor;
 
   public MongoSourceTask() {
     this(new SystemTime());
@@ -255,13 +255,13 @@ public class MongoSourceTask extends SourceTask {
     invalidatedCursor = false;
   }
 
-  MongoCursor<BsonDocument> createCursor(
+  MongoCursor<? extends BsonDocument> createCursor(
       final MongoSourceConfig sourceConfig, final MongoClient mongoClient) {
     LOGGER.debug("Creating a MongoCursor");
     return tryCreateCursor(sourceConfig, mongoClient, getResumeToken(sourceConfig));
   }
 
-  private MongoCursor<BsonDocument> tryCreateCursor(
+  private MongoCursor<? extends BsonDocument> tryCreateCursor(
       final MongoSourceConfig sourceConfig,
       final MongoClient mongoClient,
       final BsonDocument resumeToken) {

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/BsonSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/BsonSchemaAndValueProducer.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.producer;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+
+import org.bson.BsonBinaryWriter;
+import org.bson.BsonDocument;
+import org.bson.BsonValue;
+import org.bson.codecs.BsonValueCodec;
+import org.bson.codecs.Codec;
+import org.bson.codecs.EncoderContext;
+import org.bson.io.BasicOutputBuffer;
+
+import com.mongodb.kafka.connect.source.MongoSourceConfig;
+
+class BsonSchemaAndValueProducer implements SchemaAndValueProducer {
+  private static final Codec<BsonValue> BSON_VALUE_CODEC = new BsonValueCodec();
+
+  @Override
+  public SchemaAndValue create(
+      final MongoSourceConfig config, final BsonDocument changeStreamDocument) {
+    return new SchemaAndValue(Schema.BYTES_SCHEMA, documentToByteBuffer(changeStreamDocument));
+  }
+
+  private byte[] documentToByteBuffer(final BsonDocument document) {
+    BasicOutputBuffer buffer = new BasicOutputBuffer();
+    try (BsonBinaryWriter writer = new BsonBinaryWriter(buffer)) {
+      BSON_VALUE_CODEC.encode(writer, document, EncoderContext.builder().build());
+    }
+    return buffer.toByteArray(); // Use a copied truncated byte[] value
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/RawJsonStringSchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/RawJsonStringSchemaAndValueProducer.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.producer;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.kafka.connect.source.MongoSourceConfig;
+
+class RawJsonStringSchemaAndValueProducer implements SchemaAndValueProducer {
+
+  @Override
+  public SchemaAndValue create(
+      final MongoSourceConfig config, final BsonDocument changeStreamDocument) {
+    return new SchemaAndValue(Schema.STRING_SCHEMA, changeStreamDocument.toJson());
+  }
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducer.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.producer;
+
+import org.apache.kafka.connect.data.SchemaAndValue;
+
+import org.bson.BsonDocument;
+
+import com.mongodb.kafka.connect.source.MongoSourceConfig;
+
+public interface SchemaAndValueProducer {
+  SchemaAndValue create(MongoSourceConfig config, BsonDocument changeStreamDocument);
+}

--- a/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducers.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducers.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.producer;
+
+public final class SchemaAndValueProducers {
+
+  public static final SchemaAndValueProducer BSON_SCHEMA_AND_VALUE_PRODUCER =
+      new BsonSchemaAndValueProducer();
+  public static final SchemaAndValueProducer RAW_JSON_STRING_SCHEMA_AND_VALUE_PRODUCER =
+      new RawJsonStringSchemaAndValueProducer();
+
+  private SchemaAndValueProducers() {}
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/MongoSourceConfigTest.java
@@ -20,6 +20,8 @@ import static com.mongodb.kafka.connect.source.MongoSourceConfig.BATCH_SIZE_CONF
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.COLLATION_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.CONNECTION_URI_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.FULL_DOCUMENT_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_FORMAT_KEY_CONFIG;
+import static com.mongodb.kafka.connect.source.MongoSourceConfig.OUTPUT_FORMAT_VALUE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.PIPELINE_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_AWAIT_TIME_MS_CONFIG;
 import static com.mongodb.kafka.connect.source.MongoSourceConfig.POLL_MAX_BATCH_SIZE_CONFIG;
@@ -52,6 +54,8 @@ import com.mongodb.client.model.CollationMaxVariable;
 import com.mongodb.client.model.CollationStrength;
 import com.mongodb.client.model.changestream.FullDocument;
 
+import com.mongodb.kafka.connect.source.MongoSourceConfig.OutputFormat;
+
 import com.github.jcustenborder.kafka.connect.utils.config.MarkdownFormatter;
 
 class MongoSourceConfigTest {
@@ -68,7 +72,7 @@ class MongoSourceConfigTest {
 
   @Test
   @DisplayName("test client uri")
-  void tesClientUri() {
+  void testClientUri() {
     assertAll(
         "Client uri",
         () ->
@@ -81,6 +85,25 @@ class MongoSourceConfigTest {
                     .getConnectionString()
                     .toString()),
         () -> assertInvalid(CONNECTION_URI_CONFIG, "invalid connection string"));
+  }
+
+  @Test
+  @DisplayName("test output format")
+  void testOutputFormat() {
+    assertAll(
+        "Output format",
+        () -> assertEquals(OutputFormat.JSON, createSourceConfig().getKeyOutputFormat()),
+        () -> assertEquals(OutputFormat.JSON, createSourceConfig().getValueOutputFormat()),
+        () ->
+            assertEquals(
+                OutputFormat.BSON,
+                createSourceConfig(OUTPUT_FORMAT_KEY_CONFIG, "bson").getKeyOutputFormat()),
+        () ->
+            assertEquals(
+                OutputFormat.BSON,
+                createSourceConfig(OUTPUT_FORMAT_VALUE_CONFIG, "bson").getValueOutputFormat()),
+        () -> assertInvalid(OUTPUT_FORMAT_KEY_CONFIG, "avro"),
+        () -> assertInvalid(OUTPUT_FORMAT_VALUE_CONFIG, "avro"));
   }
 
   @Test

--- a/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/producer/SchemaAndValueProducerTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.producer;
+
+import static com.mongodb.kafka.connect.source.SourceTestHelper.createSourceConfig;
+import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.BSON_SCHEMA_AND_VALUE_PRODUCER;
+import static com.mongodb.kafka.connect.source.producer.SchemaAndValueProducers.RAW_JSON_STRING_SCHEMA_AND_VALUE_PRODUCER;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.apache.kafka.connect.data.Schema;
+import org.apache.kafka.connect.data.SchemaAndValue;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import org.bson.RawBsonDocument;
+
+@RunWith(JUnitPlatform.class)
+public class SchemaAndValueProducerTest {
+
+  private static final RawBsonDocument TEST_DOCUMENT =
+      RawBsonDocument.parse(
+          "{'_id': {'_id': 1}, "
+              + "'operationType': 'insert', 'ns': {'db': 'myDB', 'coll': 'myColl'}, "
+              + "'documentKey': {'_id': 1}, "
+              + "'fullDocument': {'_id': 1, 'a': 'a', 'b': 121}}");
+
+  @Test
+  @DisplayName("test raw json string schema and value producer")
+  void testRawJsonStringSchemaAndValueProducer() {
+    assertEquals(
+        new SchemaAndValue(Schema.STRING_SCHEMA, TEST_DOCUMENT.toJson()),
+        RAW_JSON_STRING_SCHEMA_AND_VALUE_PRODUCER.create(createSourceConfig(), TEST_DOCUMENT));
+  }
+
+  @Test
+  @DisplayName("test bson schema and value producer")
+  void testBsonSchemaAndValueProducer() {
+    SchemaAndValue actual =
+        BSON_SCHEMA_AND_VALUE_PRODUCER.create(createSourceConfig(), TEST_DOCUMENT);
+    assertAll(
+        "Assert schema and value matches",
+        () -> assertEquals(Schema.BYTES_SCHEMA.schema(), actual.schema()),
+        // Ensure the data length is truncated.
+        () -> assertEquals(160, ((byte[]) actual.value()).length),
+        () -> assertEquals(TEST_DOCUMENT, new RawBsonDocument((byte[]) actual.value())));
+  }
+}


### PR DESCRIPTION
Also added support for outputting different key and value data types.

KAFKA-122

https://spruce.mongodb.com/version/5f11a35a32f41709a45d12c0/tasks
