### PR TITLE
Added configurable json formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ## 1.3.0
   - [KAFKA-129](https://jira.mongodb.org/browse/KAFKA-129) Added support for Bson bytes in the Sink connector.
-  - [KAFKA-122](https://jira.mongodb.org/browse/KAFKA-12) Added support for creating Bson bytes data in the Source connector.
+  - [KAFKA-122](https://jira.mongodb.org/browse/KAFKA-122) Added support for creating Bson bytes data in the Source connector.
+  - [KAFKA-99](https://jira.mongodb.org/browse/KAFKA-99) Added support for custom Json formatting
 
 ## 1.2.0
   - [KAFKA-92](https://jira.mongodb.org/browse/KAFKA-92) Allow the Sink connector to use multiple tasks.

--- a/src/main/java/com/mongodb/kafka/connect/source/json/formatter/DefaultJson.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/json/formatter/DefaultJson.java
@@ -14,21 +14,16 @@
  * limitations under the License.
  */
 
-package com.mongodb.kafka.connect.source.producer;
+package com.mongodb.kafka.connect.source.json.formatter;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
 
-import org.bson.BsonDocument;
+public class DefaultJson implements JsonWriterSettingsProvider {
 
-import com.mongodb.kafka.connect.source.MongoSourceConfig;
-
-class RawJsonStringSchemaAndValueProducer implements SchemaAndValueProducer {
-
+  @SuppressWarnings("deprecation")
   @Override
-  public SchemaAndValue create(
-      final MongoSourceConfig config, final BsonDocument changeStreamDocument) {
-    return new SchemaAndValue(
-        Schema.STRING_SCHEMA, changeStreamDocument.toJson(config.getJsonWriterSettings()));
+  public JsonWriterSettings getJsonWriterSettings() {
+    return JsonWriterSettings.builder().outputMode(JsonMode.STRICT).build();
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/json/formatter/ExtendedJson.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/json/formatter/ExtendedJson.java
@@ -14,21 +14,15 @@
  * limitations under the License.
  */
 
-package com.mongodb.kafka.connect.source.producer;
+package com.mongodb.kafka.connect.source.json.formatter;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
 
-import org.bson.BsonDocument;
-
-import com.mongodb.kafka.connect.source.MongoSourceConfig;
-
-class RawJsonStringSchemaAndValueProducer implements SchemaAndValueProducer {
+public class ExtendedJson implements JsonWriterSettingsProvider {
 
   @Override
-  public SchemaAndValue create(
-      final MongoSourceConfig config, final BsonDocument changeStreamDocument) {
-    return new SchemaAndValue(
-        Schema.STRING_SCHEMA, changeStreamDocument.toJson(config.getJsonWriterSettings()));
+  public JsonWriterSettings getJsonWriterSettings() {
+    return JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build();
   }
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/json/formatter/JsonWriterSettingsProvider.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/json/formatter/JsonWriterSettingsProvider.java
@@ -14,21 +14,10 @@
  * limitations under the License.
  */
 
-package com.mongodb.kafka.connect.source.producer;
+package com.mongodb.kafka.connect.source.json.formatter;
 
-import org.apache.kafka.connect.data.Schema;
-import org.apache.kafka.connect.data.SchemaAndValue;
+import org.bson.json.JsonWriterSettings;
 
-import org.bson.BsonDocument;
-
-import com.mongodb.kafka.connect.source.MongoSourceConfig;
-
-class RawJsonStringSchemaAndValueProducer implements SchemaAndValueProducer {
-
-  @Override
-  public SchemaAndValue create(
-      final MongoSourceConfig config, final BsonDocument changeStreamDocument) {
-    return new SchemaAndValue(
-        Schema.STRING_SCHEMA, changeStreamDocument.toJson(config.getJsonWriterSettings()));
-  }
+public interface JsonWriterSettingsProvider {
+  JsonWriterSettings getJsonWriterSettings();
 }

--- a/src/main/java/com/mongodb/kafka/connect/source/json/formatter/SimplifiedJson.java
+++ b/src/main/java/com/mongodb/kafka/connect/source/json/formatter/SimplifiedJson.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.json.formatter;
+
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+
+public class SimplifiedJson implements JsonWriterSettingsProvider {
+
+  @Override
+  public JsonWriterSettings getJsonWriterSettings() {
+    return JsonWriterSettings.builder()
+        .outputMode(JsonMode.RELAXED)
+        .binaryConverter(
+            (value, writer) ->
+                writer.writeString(Base64.getEncoder().encodeToString(value.getData())))
+        .dateTimeConverter(
+            (value, writer) -> {
+              ZonedDateTime zonedDateTime = Instant.ofEpochMilli(value).atZone(ZoneOffset.UTC);
+              writer.writeString(DateTimeFormatter.ISO_DATE_TIME.format(zonedDateTime));
+            })
+        .decimal128Converter((value, writer) -> writer.writeString(value.toString()))
+        .objectIdConverter((value, writer) -> writer.writeString(value.toHexString()))
+        .symbolConverter((value, writer) -> writer.writeString(value))
+        .build();
+  }
+}

--- a/src/test/java/com/mongodb/kafka/connect/source/json/formatter/JsonWriterSettingsProviderTest.java
+++ b/src/test/java/com/mongodb/kafka/connect/source/json/formatter/JsonWriterSettingsProviderTest.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2008-present MongoDB, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.mongodb.kafka.connect.source.json.formatter;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.runner.JUnitPlatform;
+import org.junit.runner.RunWith;
+
+import org.bson.BsonDocument;
+import org.bson.json.JsonMode;
+import org.bson.json.JsonWriterSettings;
+
+@RunWith(JUnitPlatform.class)
+public class JsonWriterSettingsProviderTest {
+
+  private static final BsonDocument DEFAULT_TEST_DOCUMENT =
+      BsonDocument.parse(
+          "{'_id': {'$oid': '5f15aab12435743f9bd126a4'}, "
+              + "'myString': 'some foo bla text', "
+              + "'myInt': 42, "
+              + "'myDouble': {'$numberDouble': '20.21'}, "
+              + "'mySubDoc': {'A': {'$binary': {'base64': 'S2Fma2Egcm9ja3Mh', 'subType': '00'}}, "
+              + "  'B': {'$date': {'$numberLong': '1577863627000'}}, 'C': {'$numberDecimal': '12345.6789'}}, "
+              + "'myArray': [{'$binary': {'base64': 'S2Fma2Egcm9ja3Mh', 'subType': '00'}}, "
+              + "  {'$date': {'$numberLong': '1577863627000'}}, {'$numberDecimal': '12345.6789'}], "
+              + "'myBytes': {'$binary': {'base64': 'S2Fma2Egcm9ja3Mh', 'subType': '00'}}, "
+              + "'myDate': {'$date': {'$numberLong': '1577863627000'}}, "
+              + "'myDecimal': {'$numberDecimal': '12345.6789'}}");
+
+  private static final BsonDocument EXTENDED_TEST_DOCUMENT =
+      BsonDocument.parse(
+          "{'_id': {'$oid': '5f15aab12435743f9bd126a4'}, "
+              + "'myString': 'some foo bla text', "
+              + "'myInt': {'$numberInt': '42'}, "
+              + "'myDouble': {'$numberDouble': '20.21'}, "
+              + "'mySubDoc': {'A': {'$binary': {'base64': 'S2Fma2Egcm9ja3Mh', 'subType': '00'}}, "
+              + "  'B': {'$date': {'$numberLong': '1577863627000'}}, 'C': {'$numberDecimal': '12345.6789'}}, "
+              + "'myArray': [{'$binary': {'base64': 'S2Fma2Egcm9ja3Mh', 'subType': '00'}}, "
+              + "  {'$date': {'$numberLong': '1577863627000'}}, {'$numberDecimal': '12345.6789'}], "
+              + "'myBytes': {'$binary': {'base64': 'S2Fma2Egcm9ja3Mh', 'subType': '00'}}, "
+              + "'myDate': {'$date': {'$numberLong': '1577863627000'}}, "
+              + "'myDecimal': {'$numberDecimal': '12345.6789'}}");
+
+  private static final BsonDocument SIMPLIFIED_TEST_DOCUMENT =
+      BsonDocument.parse(
+          "{_id: '5f15aab12435743f9bd126a4', "
+              + "myString: 'some foo bla text', "
+              + "myInt: 42, "
+              + "myDouble: 20.21, "
+              + "mySubDoc: {A: 'S2Fma2Egcm9ja3Mh', B: '2020-01-01T07:27:07Z', C: '12345.6789'},"
+              + "myArray: ['S2Fma2Egcm9ja3Mh', '2020-01-01T07:27:07Z', '12345.6789'],"
+              + "myBytes: 'S2Fma2Egcm9ja3Mh', "
+              + "myDate: '2020-01-01T07:27:07Z', "
+              + "myDecimal: '12345.6789'}");
+
+  @Test
+  @DisplayName("test default json settings")
+  void testDefaultJson() {
+    JsonWriterSettings jsonWriterSettings = new DefaultJson().getJsonWriterSettings();
+    assertEquals(DEFAULT_TEST_DOCUMENT.toJson(), EXTENDED_TEST_DOCUMENT.toJson(jsonWriterSettings));
+  }
+
+  @Test
+  @DisplayName("test extended json settings")
+  void testExtendedJson() {
+    JsonWriterSettings jsonWriterSettings = new ExtendedJson().getJsonWriterSettings();
+    assertEquals(
+        EXTENDED_TEST_DOCUMENT.toJson(
+            JsonWriterSettings.builder().outputMode(JsonMode.EXTENDED).build()),
+        EXTENDED_TEST_DOCUMENT.toJson(jsonWriterSettings));
+  }
+
+  @Test
+  @DisplayName("test simplified json settings")
+  void testSimplifiedJson() {
+    JsonWriterSettings jsonWriterSettings = new SimplifiedJson().getJsonWriterSettings();
+    assertEquals(
+        SIMPLIFIED_TEST_DOCUMENT.toJson(), EXTENDED_TEST_DOCUMENT.toJson(jsonWriterSettings));
+  }
+}


### PR DESCRIPTION
New configuration option: output.json.formatter

There are 3 available formatters:

  * com.mongodb.kafka.connect.source.json.formatter.DefaultJson: The legacy strict json formatter
  * com.mongodb.kafka.connect.source.json.formatter.ExtendedJson: The fully type safe extended json formatter
  * com.mongodb.kafka.connect.source.json.formatter.SimplifiedJson: Simplified Json
    with ObjectId, Decimals, Dates and Binary values all represented as strings.

Users can also provide their own implementation of the com.mongodb.kafka.connect.source.json.formatter
which then must be added to the classpath.

KAFKA-122